### PR TITLE
Allow beta.mondaynight.bid origin and unify CORS with WS check

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ Any environment variables take precedence over values defined in YAML. The defau
 
 ```yaml
 host: https://mondaynight.bid
-allowedOrigins: []
+# Browser origins allowed for both CORS (REST) and the WebSocket upgrade.
+# When empty, only `host` is permitted.
+allowedOrigins:
+  - https://mondaynight.bid
+  - https://beta.mondaynight.bid
 log:
   disableAccessLogs: false
   level: info
@@ -103,6 +107,13 @@ email:
   templatesDir: templates
   disable: false
 ```
+
+> **Note on `allowedOrigins`:** this single list is enforced by both the CORS
+> layer (REST) and the WebSocket upgrade check, so the two can never disagree
+> about which browser origins are permitted. When developing locally against a
+> front-end on a different origin (e.g. `http://localhost:8080`), add that origin
+> to `allowedOrigins` or set `MNP_ALLOWED_ORIGINS=http://localhost:8080` — a
+> missing entry now blocks REST as well as the WebSocket.
 
 You can generate a YAML file with the defaults by running:
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -87,7 +87,11 @@ func main() {
 		EmailTemplates: emailTemplates,
 	})
 
+	// Share the same origin allowlist as the WebSocket upgrade check so the two
+	// layers cannot diverge. Previously CORS was left unset (allow-all), which
+	// let REST requests through from origins the WebSocket check would reject.
 	c := cors.New(cors.Options{
+		AllowedOrigins: cfg.BrowserOrigins(),
 		AllowedHeaders: []string{"Origin", "Accept", "Content-Type", "X-Requested-With", "Authorization"},
 		AllowedMethods: []string{http.MethodGet, http.MethodPost, http.MethodDelete},
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,10 @@ import (
 
 var defaultConfig = Config{
 	Host: "https://mondaynight.bid",
+	AllowedOrigins: []string{
+		"https://mondaynight.bid",
+		"https://beta.mondaynight.bid",
+	},
 	Log: Log{
 		DisableAccessLogs: false,
 		Level:             "info",
@@ -37,7 +41,9 @@ var defaultConfig = Config{
 // Config provides configuration for Monday Night Poker
 type Config struct {
 	Host string
-	// AllowedOrigins is the list of origins allowed to open a WebSocket connection.
+	// AllowedOrigins is the single list of browser origins permitted to make
+	// cross-origin requests. It governs BOTH the HTTP CORS layer and the
+	// WebSocket upgrade origin check, so the two policies never drift apart.
 	// If empty, only Host is allowed.
 	AllowedOrigins    []string `yaml:"allowedOrigins" envconfig:"allowed_origins"`
 	Log               Log
@@ -49,8 +55,11 @@ type Config struct {
 	Email             Email
 }
 
-// WebSocketOrigins returns the origins allowed to open a WebSocket connection
-func (c Config) WebSocketOrigins() []string {
+// BrowserOrigins returns the browser origins permitted to make cross-origin
+// requests. The same list is shared by the HTTP CORS layer and the WebSocket
+// upgrade origin check so they cannot diverge. When AllowedOrigins is unset it
+// falls back to Host.
+func (c Config) BrowserOrigins() []string {
 	if len(c.AllowedOrigins) > 0 {
 		return c.AllowedOrigins
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,12 +38,21 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, "dealer@mondaynight.bid", cfg.Email.Sender)
 }
 
-func TestConfig_WebSocketOrigins(t *testing.T) {
+func TestConfig_BrowserOrigins(t *testing.T) {
+	// with no AllowedOrigins set, it falls back to Host
 	cfg := Config{Host: "https://mondaynight.bid"}
-	assert.Equal(t, []string{"https://mondaynight.bid"}, cfg.WebSocketOrigins())
+	assert.Equal(t, []string{"https://mondaynight.bid"}, cfg.BrowserOrigins())
 
 	cfg.AllowedOrigins = []string{"http://localhost:8080", "https://mondaynight.bid"}
-	assert.Equal(t, []string{"http://localhost:8080", "https://mondaynight.bid"}, cfg.WebSocketOrigins())
+	assert.Equal(t, []string{"http://localhost:8080", "https://mondaynight.bid"}, cfg.BrowserOrigins())
+}
+
+func TestDefaultConfig_AllowsProdAndBeta(t *testing.T) {
+	// the default allowlist governs both CORS and the WebSocket upgrade, and must
+	// include both the production and beta frontends out of the box
+	origins := DefaultConfig().BrowserOrigins()
+	assert.Contains(t, origins, "https://mondaynight.bid")
+	assert.Contains(t, origins, "https://beta.mondaynight.bid")
 }
 
 func setEnv(key, val string) func() {

--- a/internal/mux/table_ws.go
+++ b/internal/mux/table_ws.go
@@ -34,7 +34,7 @@ func (m *Mux) checkOrigin(r *http.Request) bool {
 		return false
 	}
 
-	for _, allowed := range m.cfg.WebSocketOrigins() {
+	for _, allowed := range m.cfg.BrowserOrigins() {
 		allowedURL, err := url.Parse(allowed)
 		if err != nil {
 			continue


### PR DESCRIPTION
The WebSocket upgrade check (Mux.checkOrigin) validated the Origin header against Config.WebSocketOrigins(), which fell back to just Host (https://mondaynight.bid) when AllowedOrigins was unset. Meanwhile the HTTP CORS layer set no AllowedOrigins, so rs/cors defaulted to allow-all. That mismatch is why REST requests from https://beta.mondaynight.bid succeeded while the game WebSocket handshake was rejected and the client retried forever.

- Add https://beta.mondaynight.bid (alongside prod) to the default AllowedOrigins so both frontends work out of the box; still overridable via allowedOrigins / MNP_ALLOWED_ORIGINS.
- Rename WebSocketOrigins() to BrowserOrigins() and feed the same list to the CORS layer so REST and WebSocket origin policies can never diverge.
- Document the shared allowlist and the local-dev implication in README.


Claude-Session: https://claude.ai/code/session_019EYXD7twzahn5TBbYEALRB