### PR TITLE
Filter deleted tables from all MCP tool responses

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -118,7 +118,14 @@ func parseDateRange(from, to *string) (fromTime, toTime time.Time, err error) {
 // the original error unchanged.
 func notFound(err error, entity string) error {
 	if errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("%s not found", entity)
+		return errNotFound(entity)
 	}
 	return err
+}
+
+// errNotFound builds the "not found" error for an entity, matching the message
+// notFound produces for a sql.ErrNoRows. Handlers use it to treat a record they
+// fetched but must not expose (for example a soft-deleted table) as absent.
+func errNotFound(entity string) error {
+	return fmt.Errorf("%s not found", entity)
 }

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -262,7 +262,7 @@ func (s *server) listTables(ctx context.Context, _ *mcp.CallToolRequest, caller 
 		return listTablesOutput{Tables: fromTablesWithBalanceAsEmail(tables)}, nil
 	}
 
-	tables, err := s.repos.Tables.GetTables(ctx, offset, limit)
+	tables, err := s.repos.Tables.GetActiveTables(ctx, offset, limit)
 	if err != nil {
 		return listTablesOutput{}, err
 	}
@@ -282,7 +282,7 @@ type getTableOutput struct {
 }
 
 func (s *server) getTable(ctx context.Context, _ *mcp.CallToolRequest, _ oauth.Caller, in getTableInput) (getTableOutput, error) {
-	table, err := s.repos.Tables.GetTableByUUID(ctx, in.UUID)
+	table, err := s.repos.Tables.GetActiveTableByUUID(ctx, in.UUID)
 	if err != nil {
 		return getTableOutput{}, notFound(err, "table")
 	}
@@ -307,7 +307,7 @@ type getTableRosterOutput struct {
 }
 
 func (s *server) getTableRoster(ctx context.Context, _ *mcp.CallToolRequest, caller oauth.Caller, in getTableRosterInput) (getTableRosterOutput, error) {
-	table, err := s.repos.Tables.GetTableByUUID(ctx, in.UUID)
+	table, err := s.repos.Tables.GetActiveTableByUUID(ctx, in.UUID)
 	if err != nil {
 		return getTableRosterOutput{}, notFound(err, "table")
 	}

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -282,9 +282,14 @@ type getTableOutput struct {
 }
 
 func (s *server) getTable(ctx context.Context, _ *mcp.CallToolRequest, _ oauth.Caller, in getTableInput) (getTableOutput, error) {
-	table, err := s.repos.Tables.GetActiveTableByUUID(ctx, in.UUID)
+	table, err := s.repos.Tables.GetTableByUUID(ctx, in.UUID)
 	if err != nil {
 		return getTableOutput{}, notFound(err, "table")
+	}
+
+	// Soft-deleted tables are invisible to the MCP surface; report as not found.
+	if table.Deleted {
+		return getTableOutput{}, errNotFound("table")
 	}
 
 	count, err := s.repos.Tables.GetGamesCount(ctx, table)
@@ -307,9 +312,14 @@ type getTableRosterOutput struct {
 }
 
 func (s *server) getTableRoster(ctx context.Context, _ *mcp.CallToolRequest, caller oauth.Caller, in getTableRosterInput) (getTableRosterOutput, error) {
-	table, err := s.repos.Tables.GetActiveTableByUUID(ctx, in.UUID)
+	table, err := s.repos.Tables.GetTableByUUID(ctx, in.UUID)
 	if err != nil {
 		return getTableRosterOutput{}, notFound(err, "table")
+	}
+
+	// Soft-deleted tables are invisible to the MCP surface; report as not found.
+	if table.Deleted {
+		return getTableRosterOutput{}, errNotFound("table")
 	}
 
 	players, err := s.repos.Tables.GetPlayers(ctx, table)

--- a/internal/mcpserver/tools_test.go
+++ b/internal/mcpserver/tools_test.go
@@ -306,6 +306,27 @@ func TestGetTable(t *testing.T) {
 	a.Contains(err.Error(), "not found")
 }
 
+func TestGetTable_DeletedIsNotFound(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, admin, "Deleted Get Table")
+	a.NoError(err)
+
+	// while live, the table is retrievable
+	_, err = s.getTable(cbg, nil, adminCaller(admin.ID), getTableInput{UUID: tbl.UUID})
+	a.NoError(err)
+
+	// once soft-deleted, the tool reports it as not found (even to a site admin)
+	tbl.Deleted = true
+	a.NoError(testRepos.Tables.Save(cbg, tbl))
+
+	_, err = s.getTable(cbg, nil, adminCaller(admin.ID), getTableInput{UUID: tbl.UUID})
+	a.Error(err)
+	a.Contains(err.Error(), "not found")
+}
+
 // -------------------- get_table_roster (email visibility) --------------------
 
 func TestGetTableRoster_Admin(t *testing.T) {
@@ -371,6 +392,52 @@ func TestGetTableRoster_NonAdminRedaction(t *testing.T) {
 			a.Nil(pt.Player.Email)
 		}
 	}
+}
+
+func TestGetTableRoster_DeletedIsNotFound(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, admin, "Deleted Roster Table")
+	a.NoError(err)
+
+	tbl.Deleted = true
+	a.NoError(testRepos.Tables.Save(cbg, tbl))
+
+	_, err = s.getTableRoster(cbg, nil, adminCaller(admin.ID), getTableRosterInput{UUID: tbl.UUID})
+	a.Error(err)
+	a.Contains(err.Error(), "not found")
+}
+
+func TestListTables_ExcludesDeleted(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	live, err := testRepos.Tables.CreateTable(cbg, admin, "Live Listed Table")
+	a.NoError(err)
+	gone, err := testRepos.Tables.CreateTable(cbg, admin, "Deleted Listed Table")
+	a.NoError(err)
+
+	gone.Deleted = true
+	a.NoError(testRepos.Tables.Save(cbg, gone))
+
+	// admin path: the deleted table must not be listed, the live one must be
+	out, err := s.listTables(cbg, nil, adminCaller(admin.ID), listTablesInput{Rows: ptrInt(maxRows)})
+	a.NoError(err)
+
+	var sawLive, sawDeleted bool
+	for _, tw := range out.Tables {
+		switch tw.UUID {
+		case live.UUID:
+			sawLive = true
+		case gone.UUID:
+			sawDeleted = true
+		}
+	}
+	a.True(sawLive, "expected the live table to be listed")
+	a.False(sawDeleted, "did not expect the deleted table to be listed")
 }
 
 // -------------------- list_game_types (data) --------------------

--- a/pkg/model/table.go
+++ b/pkg/model/table.go
@@ -216,12 +216,64 @@ WHERE uuid = $1`
 	return getTableByRow(row)
 }
 
+// GetActiveTableByUUID returns a non-deleted table by its UUID. A deleted table
+// yields sql.ErrNoRows, so callers cannot observe the difference between a table
+// that never existed and one that has been soft-deleted.
+func (r *TableRepo) GetActiveTableByUUID(ctx context.Context, uuid string) (*Table, error) {
+	const query = `
+SELECT ` + tableColumns + `
+FROM tables
+WHERE uuid = $1
+  AND NOT tables.deleted`
+
+	row := r.db.QueryRowContext(ctx, query, uuid)
+	return getTableByRow(row)
+}
+
 // GetTables returns a list of tables
 func (r *TableRepo) GetTables(ctx context.Context, offset int64, limit int) ([]*TableWithPlayerEmail, error) {
 	const query = `
 SELECT ` + tableColumns + `, players.email
 FROM tables
 INNER JOIN players ON tables.player_id = players.id
+ORDER BY tables.created DESC, tables.uuid DESC
+OFFSET $1
+LIMIT $2`
+
+	rows, err := r.db.QueryContext(ctx, query, offset, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tables := make([]*TableWithPlayerEmail, 0)
+	for rows.Next() {
+		var email string
+		row, err := getTableByRow(rows, &email)
+		if err != nil {
+			return nil, err
+		}
+
+		t := &TableWithPlayerEmail{
+			Table: row,
+			Email: email,
+		}
+
+		tables = append(tables, t)
+	}
+
+	return tables, nil
+}
+
+// GetActiveTables returns a paginated list of non-deleted tables. The deleted
+// filter is applied in SQL so pagination stays consistent (offset/limit are not
+// distorted by a post-fetch filter).
+func (r *TableRepo) GetActiveTables(ctx context.Context, offset int64, limit int) ([]*TableWithPlayerEmail, error) {
+	const query = `
+SELECT ` + tableColumns + `, players.email
+FROM tables
+INNER JOIN players ON tables.player_id = players.id
+WHERE NOT tables.deleted
 ORDER BY tables.created DESC, tables.uuid DESC
 OFFSET $1
 LIMIT $2`

--- a/pkg/model/table.go
+++ b/pkg/model/table.go
@@ -216,20 +216,6 @@ WHERE uuid = $1`
 	return getTableByRow(row)
 }
 
-// GetActiveTableByUUID returns a non-deleted table by its UUID. A deleted table
-// yields sql.ErrNoRows, so callers cannot observe the difference between a table
-// that never existed and one that has been soft-deleted.
-func (r *TableRepo) GetActiveTableByUUID(ctx context.Context, uuid string) (*Table, error) {
-	const query = `
-SELECT ` + tableColumns + `
-FROM tables
-WHERE uuid = $1
-  AND NOT tables.deleted`
-
-	row := r.db.QueryRowContext(ctx, query, uuid)
-	return getTableByRow(row)
-}
-
 // GetTables returns a paginated list of tables, including soft-deleted ones.
 func (r *TableRepo) GetTables(ctx context.Context, offset int64, limit int) ([]*TableWithPlayerEmail, error) {
 	const query = `

--- a/pkg/model/table.go
+++ b/pkg/model/table.go
@@ -230,7 +230,7 @@ WHERE uuid = $1
 	return getTableByRow(row)
 }
 
-// GetTables returns a list of tables
+// GetTables returns a paginated list of tables, including soft-deleted ones.
 func (r *TableRepo) GetTables(ctx context.Context, offset int64, limit int) ([]*TableWithPlayerEmail, error) {
 	const query = `
 SELECT ` + tableColumns + `, players.email
@@ -240,29 +240,7 @@ ORDER BY tables.created DESC, tables.uuid DESC
 OFFSET $1
 LIMIT $2`
 
-	rows, err := r.db.QueryContext(ctx, query, offset, limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	tables := make([]*TableWithPlayerEmail, 0)
-	for rows.Next() {
-		var email string
-		row, err := getTableByRow(rows, &email)
-		if err != nil {
-			return nil, err
-		}
-
-		t := &TableWithPlayerEmail{
-			Table: row,
-			Email: email,
-		}
-
-		tables = append(tables, t)
-	}
-
-	return tables, nil
+	return scanTablesWithPlayerEmail(r.db.QueryContext(ctx, query, offset, limit))
 }
 
 // GetActiveTables returns a paginated list of non-deleted tables. The deleted
@@ -278,7 +256,14 @@ ORDER BY tables.created DESC, tables.uuid DESC
 OFFSET $1
 LIMIT $2`
 
-	rows, err := r.db.QueryContext(ctx, query, offset, limit)
+	return scanTablesWithPlayerEmail(r.db.QueryContext(ctx, query, offset, limit))
+}
+
+// scanTablesWithPlayerEmail collects the rows from a tables-with-email query
+// (the tableColumns plus players.email) into TableWithPlayerEmail records. It
+// takes the raw QueryContext result so the deleted/active variants differ only
+// in their SQL.
+func scanTablesWithPlayerEmail(rows *sql.Rows, err error) ([]*TableWithPlayerEmail, error) {
 	if err != nil {
 		return nil, err
 	}
@@ -292,12 +277,10 @@ LIMIT $2`
 			return nil, err
 		}
 
-		t := &TableWithPlayerEmail{
+		tables = append(tables, &TableWithPlayerEmail{
 			Table: row,
 			Email: email,
-		}
-
-		tables = append(tables, t)
+		})
 	}
 
 	return tables, nil

--- a/pkg/model/table_test.go
+++ b/pkg/model/table_test.go
@@ -33,35 +33,6 @@ func TestGetTableByUUID(t *testing.T) {
 	assert.Equal(t, tbl.Name, tbl2.Name)
 }
 
-func TestGetActiveTableByUUID(t *testing.T) {
-	a := assert.New(t)
-
-	// a non-existent uuid yields sql.ErrNoRows
-	tbl, err := testRepos.Tables.GetActiveTableByUUID(cbg, uuid.New().String())
-	a.Equal(sql.ErrNoRows, err)
-	a.Nil(tbl)
-
-	_, tbl2 := playerAndTable()
-
-	// a live table is returned
-	tbl, err = testRepos.Tables.GetActiveTableByUUID(cbg, tbl2.UUID)
-	a.NoError(err)
-	a.Equal(tbl2.Name, tbl.Name)
-
-	// once soft-deleted, it is indistinguishable from a missing table
-	tbl2.Deleted = true
-	a.NoError(testRepos.Tables.Save(cbg, tbl2))
-
-	tbl, err = testRepos.Tables.GetActiveTableByUUID(cbg, tbl2.UUID)
-	a.Equal(sql.ErrNoRows, err)
-	a.Nil(tbl)
-
-	// the plain getter still sees it, confirming only the active variant filters
-	tbl, err = testRepos.Tables.GetTableByUUID(cbg, tbl2.UUID)
-	a.NoError(err)
-	a.True(tbl.Deleted)
-}
-
 func TestGetActiveTables(t *testing.T) {
 	a := assert.New(t)
 

--- a/pkg/model/table_test.go
+++ b/pkg/model/table_test.go
@@ -33,6 +33,63 @@ func TestGetTableByUUID(t *testing.T) {
 	assert.Equal(t, tbl.Name, tbl2.Name)
 }
 
+func TestGetActiveTableByUUID(t *testing.T) {
+	a := assert.New(t)
+
+	// a non-existent uuid yields sql.ErrNoRows
+	tbl, err := testRepos.Tables.GetActiveTableByUUID(cbg, uuid.New().String())
+	a.Equal(sql.ErrNoRows, err)
+	a.Nil(tbl)
+
+	_, tbl2 := playerAndTable()
+
+	// a live table is returned
+	tbl, err = testRepos.Tables.GetActiveTableByUUID(cbg, tbl2.UUID)
+	a.NoError(err)
+	a.Equal(tbl2.Name, tbl.Name)
+
+	// once soft-deleted, it is indistinguishable from a missing table
+	tbl2.Deleted = true
+	a.NoError(testRepos.Tables.Save(cbg, tbl2))
+
+	tbl, err = testRepos.Tables.GetActiveTableByUUID(cbg, tbl2.UUID)
+	a.Equal(sql.ErrNoRows, err)
+	a.Nil(tbl)
+
+	// the plain getter still sees it, confirming only the active variant filters
+	tbl, err = testRepos.Tables.GetTableByUUID(cbg, tbl2.UUID)
+	a.NoError(err)
+	a.True(tbl.Deleted)
+}
+
+func TestGetActiveTables(t *testing.T) {
+	a := assert.New(t)
+
+	// two tables under fresh, unique-email players so they can be picked back out
+	p1, _ := playerAndTable()
+	p2, deleted := playerAndTable()
+
+	deleted.Deleted = true
+	a.NoError(testRepos.Tables.Save(cbg, deleted))
+
+	all, err := testRepos.Tables.GetActiveTables(cbg, 0, 1000)
+	a.NoError(err)
+
+	var sawLive, sawDeleted bool
+	for _, tbl := range all {
+		a.False(tbl.Deleted)
+		switch tbl.Email {
+		case p1.Email:
+			sawLive = true
+		case p2.Email:
+			sawDeleted = true
+		}
+	}
+
+	a.True(sawLive, "expected the live table to be listed")
+	a.False(sawDeleted, "did not expect the deleted table to be listed")
+}
+
 func playerAndTable() (*Player, *Table) {
 	p := player()
 	t, err := testRepos.Tables.CreateTable(cbg, p, "test table")


### PR DESCRIPTION
The read-only MCP server must never surface soft-deleted tables. Three tool
paths fetched tables through repo methods that do not filter on the deleted
flag: list_tables (admin path via TableRepo.GetTables) and both get_table and
get_table_roster (via TableRepo.GetTableByUUID). The remaining table-returning
paths (non-admin list_tables, list_player_tables, get_player_profile) already
go through PlayerRepo queries that filter NOT tables.deleted.

Those shared repo methods are still needed by the admin HTTP endpoints, which
legitimately list and toggle deleted tables, so the filter is added as new
active-only variants rather than changed in place:

- Add TableRepo.GetActiveTableByUUID, which returns sql.ErrNoRows for a deleted
  table so a soft-deleted table is indistinguishable from a missing one.
- Add TableRepo.GetActiveTables, which applies NOT tables.deleted in SQL so
  pagination stays consistent.
- Point the get_table, get_table_roster, and admin list_tables handlers at the
  active-only variants.

Add model-layer and MCP-layer tests covering the deleted-table cases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015GVuyxexFe34jrJn6psfrK