### PR TITLE
Add normalized game-log parsing for every game type

### DIFF
--- a/internal/mcpserver/dto_analytics.go
+++ b/internal/mcpserver/dto_analytics.go
@@ -126,7 +126,7 @@ type HandDTO struct {
 
 	AnteCents   int    `json:"anteCents" jsonschema:"the ante, in cents; zero when the game's log does not record one"`
 	AnteDisplay string `json:"anteDisplay" jsonschema:"the ante preformatted in dollars; show this rather than converting anteCents yourself"`
-	PotCents    int    `json:"potCents" jsonschema:"the pot, in cents"`
+	PotCents    int    `json:"potCents" jsonschema:"the pot, in cents. Single-pass poker variants report the final pot; round-based games (Guts, Acey Deucey) report the pot as of the last round rather than a lifetime total across every round; Little L reconstructs it as the sum of payouts"`
 	PotDisplay  string `json:"potDisplay" jsonschema:"the pot preformatted in dollars; show this rather than converting potCents yourself"`
 
 	Rounds int       `json:"rounds" jsonschema:"the number of rounds or hands the game ran; games that resolve in a single pass report 1"`

--- a/internal/mcpserver/dto_analytics.go
+++ b/internal/mcpserver/dto_analytics.go
@@ -1,0 +1,395 @@
+package mcpserver
+
+import (
+	"fmt"
+	"time"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/model"
+	"mondaynightpoker-server/pkg/money"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+)
+
+// formatRate renders a 0..1 ratio as a percentage string for display, matching the
+// discipline the money fields follow: emit a preformatted string alongside the raw
+// value so a caller never has to decide how to render it.
+func formatRate(rate float64) string {
+	return fmt.Sprintf("%.1f%%", rate*100)
+}
+
+// RateDTO is a computed ratio paired with a display string.
+//
+// It is a pointer field everywhere it appears so an undefined rate is absent from
+// the JSON rather than reported as zero. A player who has never reached a showdown
+// has no showdown win rate, and "0.0%" would read as though they always lose.
+type RateDTO struct {
+	Value   float64 `json:"value" jsonschema:"the ratio, between 0 and 1"`
+	Display string  `json:"display" jsonschema:"the ratio preformatted as a percentage; show this to the user rather than converting value yourself"`
+}
+
+// newRate builds a RateDTO, returning nil when the underlying statistic is
+// undefined so the field is omitted.
+func newRate(value float64, ok bool) *RateDTO {
+	if !ok {
+		return nil
+	}
+
+	return &RateDTO{Value: value, Display: formatRate(value)}
+}
+
+// CardDTO is a single card.
+type CardDTO struct {
+	Rank    int    `json:"rank" jsonschema:"the card's rank, 2-14 where 11-14 are jack, queen, king, ace"`
+	Suit    string `json:"suit" jsonschema:"the card's suit"`
+	IsWild  bool   `json:"isWild,omitempty" jsonschema:"whether the card is wild"`
+	Display string `json:"display,omitempty" jsonschema:"the card preformatted for display; show this to the user. Omitted for a card whose suit is not recognized, which a hidden or placeholder card in an older log can be"`
+}
+
+// knownSuits are the suits deck.Card.String can render.
+var knownSuits = map[deck.Suit]bool{
+	deck.Hearts:   true,
+	deck.Clubs:    true,
+	deck.Diamonds: true,
+	deck.Spades:   true,
+	deck.Stars:    true,
+}
+
+// cardDisplay renders a card for display, returning an empty string rather than
+// letting deck.Card.String panic.
+//
+// These cards come out of persisted jsonb rather than a live deck, so nothing
+// guarantees the suit is one the renderer knows: a hidden hand, a placeholder, or
+// a log written by an older version can all decode into a card String would panic
+// on. Losing one display string is a fair trade for a tool that cannot be crashed
+// by a row in the database.
+func cardDisplay(c *deck.Card) string {
+	if !knownSuits[c.Suit] {
+		return ""
+	}
+
+	return c.String()
+}
+
+// fromCards maps deck cards to DTOs, skipping nils. A nil card is how the game
+// packages represent a card that was never dealt or is not visible.
+func fromCards(cards []*deck.Card) []CardDTO {
+	out := make([]CardDTO, 0, len(cards))
+	for _, c := range cards {
+		if c == nil {
+			continue
+		}
+
+		out = append(out, CardDTO{
+			Rank:    c.Rank,
+			Suit:    string(c.Suit),
+			IsWild:  c.IsWild,
+			Display: cardDisplay(c),
+		})
+	}
+
+	return out
+}
+
+// HandActionDTO is one normalized action within a hand.
+type HandActionDTO struct {
+	Sequence      int       `json:"sequence" jsonschema:"the action's position in the hand, starting at 0"`
+	Street        string    `json:"street,omitempty" jsonschema:"the phase of the hand the action occurred in; the vocabulary is game-specific and not comparable across game types"`
+	PlayerID      int64     `json:"playerId" jsonschema:"the acting player's id"`
+	DisplayName   string    `json:"displayName,omitempty" jsonschema:"the acting player's display name"`
+	Kind          string    `json:"kind" jsonschema:"the normalized action: fold, check, call, bet, raise, discard, trade, stay-in, drop-out, play-card, or pass"`
+	AmountCents   int       `json:"amountCents,omitempty" jsonschema:"the amount wagered by this action, in cents"`
+	AmountDisplay string    `json:"amountDisplay,omitempty" jsonschema:"the wagered amount preformatted in dollars; show this rather than converting amountCents yourself"`
+	Cards         []CardDTO `json:"cards,omitempty" jsonschema:"cards involved in the action"`
+	AllIn         bool      `json:"allIn,omitempty" jsonschema:"whether the action put the player all in"`
+}
+
+// HandParticipantDTO is one player's involvement in a hand.
+type HandParticipantDTO struct {
+	PlayerID    int64  `json:"playerId" jsonschema:"the player's id"`
+	DisplayName string `json:"displayName,omitempty" jsonschema:"the player's display name"`
+
+	StartingCards []CardDTO `json:"startingCards,omitempty" jsonschema:"the cards the player started the hand with, when the game records them"`
+	FinalCards    []CardDTO `json:"finalCards,omitempty" jsonschema:"the cards the player finished the hand with, when the game records them"`
+
+	VoluntarilyPlayed bool `json:"voluntarilyPlayed" jsonschema:"whether the player chose to commit beyond any forced ante or blind; this is the cross-game equivalent of VPIP"`
+	Folded            bool `json:"folded" jsonschema:"whether the player folded or dropped out"`
+	WentToShowdown    bool `json:"wentToShowdown" jsonschema:"whether the player was still contesting the pot when the hand resolved"`
+	Won               bool `json:"won" jsonschema:"whether the player won the hand, including hands won because everyone else folded"`
+
+	AmountWageredCents   int    `json:"amountWageredCents" jsonschema:"what the player put in through their own actions, in cents, excluding the forced ante"`
+	AmountWageredDisplay string `json:"amountWageredDisplay" jsonschema:"the wagered total preformatted in dollars; show this rather than converting amountWageredCents yourself"`
+
+	NetCents   *int    `json:"netCents,omitempty" jsonschema:"the player's net result for the hand from the ledger, in cents; absent when the hand has no ledger entry for this player"`
+	NetDisplay *string `json:"netDisplay,omitempty" jsonschema:"the net result preformatted in dollars; show this rather than converting netCents yourself"`
+}
+
+// HandDTO is a normalized, replayable summary of one completed game.
+type HandDTO struct {
+	GameID         int64     `json:"gameId" jsonschema:"the game's numeric id"`
+	TableUUID      string    `json:"tableUuid" jsonschema:"the uuid of the table the game was played at"`
+	GameType       string    `json:"gameType" jsonschema:"the game-type identifier the log was parsed as"`
+	StoredGameType string    `json:"storedGameType" jsonschema:"the game's full display name as recorded on the game row, including the options it was created with"`
+	Variant        string    `json:"variant,omitempty" jsonschema:"the sub-variant within the game type, when the game has one"`
+	Created        time.Time `json:"created" jsonschema:"when the game was created"`
+
+	AnteCents   int    `json:"anteCents" jsonschema:"the ante, in cents; zero when the game's log does not record one"`
+	AnteDisplay string `json:"anteDisplay" jsonschema:"the ante preformatted in dollars; show this rather than converting anteCents yourself"`
+	PotCents    int    `json:"potCents" jsonschema:"the pot, in cents"`
+	PotDisplay  string `json:"potDisplay" jsonschema:"the pot preformatted in dollars; show this rather than converting potCents yourself"`
+
+	Rounds int       `json:"rounds" jsonschema:"the number of rounds or hands the game ran; games that resolve in a single pass report 1"`
+	Board  []CardDTO `json:"board,omitempty" jsonschema:"shared cards, when the game has any: community cards in the poker variants, the trump card in Bourre"`
+
+	Participants []HandParticipantDTO `json:"participants" jsonschema:"each player's involvement in the hand"`
+	Actions      []HandActionDTO      `json:"actions" jsonschema:"every action taken during the hand, in order"`
+}
+
+// fromHand maps a normalized hand to a DTO, enriching it with display names and
+// the per-player net results from the ledger. names and nets may be nil.
+func fromHand(hand *gamelog.Hand, game *model.Game, names map[int64]string, nets map[int64]int) HandDTO {
+	dto := HandDTO{
+		GameID:         game.ID,
+		TableUUID:      game.TableUUID,
+		GameType:       hand.GameType,
+		StoredGameType: game.GameType,
+		Variant:        hand.Variant,
+		Created:        game.Created,
+		AnteCents:      hand.AnteCents,
+		AnteDisplay:    money.FormatCents(hand.AnteCents),
+		PotCents:       hand.PotCents,
+		PotDisplay:     money.FormatCents(hand.PotCents),
+		Rounds:         hand.Rounds,
+		Board:          fromCards(hand.Board),
+		Participants:   make([]HandParticipantDTO, 0, len(hand.Participants)),
+		Actions:        make([]HandActionDTO, 0, len(hand.Actions)),
+	}
+
+	for _, p := range hand.Participants {
+		participant := HandParticipantDTO{
+			PlayerID:             p.PlayerID,
+			DisplayName:          names[p.PlayerID],
+			StartingCards:        fromCards(p.StartingCards),
+			FinalCards:           fromCards(p.FinalCards),
+			VoluntarilyPlayed:    p.VoluntarilyPlayed,
+			Folded:               p.Folded,
+			WentToShowdown:       p.WentToShowdown,
+			Won:                  p.Won,
+			AmountWageredCents:   p.AmountWageredCents,
+			AmountWageredDisplay: money.FormatCents(p.AmountWageredCents),
+		}
+
+		if net, ok := nets[p.PlayerID]; ok {
+			display := money.FormatCents(net)
+			participant.NetCents = &net
+			participant.NetDisplay = &display
+		}
+
+		dto.Participants = append(dto.Participants, participant)
+	}
+
+	for _, a := range hand.Actions {
+		action := HandActionDTO{
+			Sequence:    a.Sequence,
+			Street:      a.Street,
+			PlayerID:    a.PlayerID,
+			DisplayName: names[a.PlayerID],
+			Kind:        string(a.Kind),
+			AmountCents: a.AmountCents,
+			Cards:       fromCards(a.Cards),
+			AllIn:       a.AllIn,
+		}
+		if a.AmountCents != 0 {
+			action.AmountDisplay = money.FormatCents(a.AmountCents)
+		}
+
+		dto.Actions = append(dto.Actions, action)
+	}
+
+	return dto
+}
+
+// TendenciesDTO is a player's behavioral profile aggregated over many hands.
+//
+// The counts are reported alongside the rates on purpose: a 100% fold rate over
+// three hands and over three hundred are very different claims, and only the counts
+// distinguish them.
+type TendenciesDTO struct {
+	HandsAnalyzed int `json:"handsAnalyzed" jsonschema:"the number of hands the player appeared in across the analyzed logs"`
+
+	HandsVoluntarilyPlayed int      `json:"handsVoluntarilyPlayed" jsonschema:"hands where the player committed beyond any forced ante or blind"`
+	VoluntaryPlayRate      *RateDTO `json:"voluntaryPlayRate,omitempty" jsonschema:"share of hands voluntarily played, the cross-game equivalent of VPIP; absent when no hands were analyzed"`
+
+	HandsFolded int      `json:"handsFolded" jsonschema:"hands the player folded or dropped out of"`
+	FoldRate    *RateDTO `json:"foldRate,omitempty" jsonschema:"share of hands folded; absent when no hands were analyzed"`
+
+	HandsToShowdown int      `json:"handsToShowdown" jsonschema:"hands the player was still contesting when the hand resolved"`
+	ShowdownRate    *RateDTO `json:"showdownRate,omitempty" jsonschema:"share of hands taken to a showdown; absent when no hands were analyzed"`
+
+	HandsWonAtShowdown int      `json:"handsWonAtShowdown" jsonschema:"contested showdowns the player won"`
+	ShowdownWinRate    *RateDTO `json:"showdownWinRate,omitempty" jsonschema:"share of contested showdowns won; absent when the player never reached one. The denominator is showdowns reached, not hands played, so folding more does not improve it"`
+
+	HandsWon int      `json:"handsWon" jsonschema:"hands the player won, including those won because everyone else folded"`
+	WinRate  *RateDTO `json:"winRate,omitempty" jsonschema:"share of hands won; absent when no hands were analyzed"`
+
+	Bets     int `json:"bets" jsonschema:"total bets"`
+	Raises   int `json:"raises" jsonschema:"total raises"`
+	Calls    int `json:"calls" jsonschema:"total calls"`
+	Checks   int `json:"checks" jsonschema:"total checks"`
+	Folds    int `json:"folds" jsonschema:"total folds and drop-outs"`
+	Discards int `json:"discards" jsonschema:"total discards"`
+	Trades   int `json:"trades" jsonschema:"total trades"`
+
+	AggressionFactor *float64 `json:"aggressionFactor,omitempty" jsonschema:"ratio of aggressive actions (bets plus raises) to calls; absent when the player has never called, where the ratio is undefined rather than infinite"`
+
+	AmountWageredCents   int    `json:"amountWageredCents" jsonschema:"total the player put into pots through their own actions, in cents, excluding forced antes"`
+	AmountWageredDisplay string `json:"amountWageredDisplay" jsonschema:"the wagered total preformatted in dollars; show this rather than converting amountWageredCents yourself"`
+}
+
+// fromTendencies maps aggregated tendencies to a DTO.
+func fromTendencies(t *gamelog.Tendencies) TendenciesDTO {
+	dto := TendenciesDTO{
+		HandsAnalyzed:          t.HandsPlayed,
+		HandsVoluntarilyPlayed: t.HandsVoluntarilyPlayed,
+		HandsFolded:            t.HandsFolded,
+		HandsToShowdown:        t.HandsToShowdown,
+		HandsWonAtShowdown:     t.HandsWonAtShowdown,
+		HandsWon:               t.HandsWon,
+		Bets:                   t.Bets,
+		Raises:                 t.Raises,
+		Calls:                  t.Calls,
+		Checks:                 t.Checks,
+		Folds:                  t.Folds,
+		Discards:               t.Discards,
+		Trades:                 t.Trades,
+		AmountWageredCents:     t.AmountWageredCents,
+		AmountWageredDisplay:   money.FormatCents(t.AmountWageredCents),
+	}
+
+	dto.VoluntaryPlayRate = newRate(t.Rate(t.HandsVoluntarilyPlayed))
+	dto.FoldRate = newRate(t.Rate(t.HandsFolded))
+	dto.ShowdownRate = newRate(t.Rate(t.HandsToShowdown))
+	dto.WinRate = newRate(t.Rate(t.HandsWon))
+	dto.ShowdownWinRate = newRate(t.ShowdownWinRate())
+
+	if factor, ok := t.AggressionFactor(); ok {
+		dto.AggressionFactor = &factor
+	}
+
+	return dto
+}
+
+// SpreadDTO describes the distribution of a series of results.
+type SpreadDTO struct {
+	Count int `json:"count" jsonschema:"the number of results in the series"`
+
+	TotalCents   int    `json:"totalCents" jsonschema:"the sum of the results, in cents"`
+	TotalDisplay string `json:"totalDisplay" jsonschema:"the total preformatted in dollars; show this rather than converting totalCents yourself"`
+
+	MeanCents   float64 `json:"meanCents" jsonschema:"the average result, in cents"`
+	MeanDisplay string  `json:"meanDisplay" jsonschema:"the average preformatted in dollars; show this rather than converting meanCents yourself"`
+
+	MedianCents   float64 `json:"medianCents" jsonschema:"the median result, in cents"`
+	MedianDisplay string  `json:"medianDisplay" jsonschema:"the median preformatted in dollars; show this rather than converting medianCents yourself"`
+
+	StdDevCents   float64 `json:"stdDevCents" jsonschema:"the sample standard deviation of the results, in cents; this is the swing measure. It is zero for fewer than two results, where it is undefined rather than small"`
+	StdDevDisplay string  `json:"stdDevDisplay" jsonschema:"the standard deviation preformatted in dollars; show this rather than converting stdDevCents yourself"`
+
+	BestCents    int    `json:"bestCents" jsonschema:"the best single result, in cents"`
+	BestDisplay  string `json:"bestDisplay" jsonschema:"the best result preformatted in dollars; show this rather than converting bestCents yourself"`
+	WorstCents   int    `json:"worstCents" jsonschema:"the worst single result, in cents"`
+	WorstDisplay string `json:"worstDisplay" jsonschema:"the worst result preformatted in dollars; show this rather than converting worstCents yourself"`
+}
+
+// fromSpread maps a model.Spread to a DTO. Fractional cents are rounded for
+// display only; the raw float is preserved for arithmetic.
+func fromSpread(s model.Spread) SpreadDTO {
+	return SpreadDTO{
+		Count:         s.Count,
+		TotalCents:    s.TotalCents,
+		TotalDisplay:  money.FormatCents(s.TotalCents),
+		MeanCents:     s.MeanCents,
+		MeanDisplay:   money.FormatCents(roundCents(s.MeanCents)),
+		MedianCents:   s.MedianCents,
+		MedianDisplay: money.FormatCents(roundCents(s.MedianCents)),
+		StdDevCents:   s.StdDevCents,
+		StdDevDisplay: money.FormatCents(roundCents(s.StdDevCents)),
+		BestCents:     s.BestCents,
+		BestDisplay:   money.FormatCents(s.BestCents),
+		WorstCents:    s.WorstCents,
+		WorstDisplay:  money.FormatCents(s.WorstCents),
+	}
+}
+
+// roundCents rounds a fractional cent amount to the nearest whole cent, halves
+// away from zero, for rendering through the shared money formatter.
+func roundCents(cents float64) int {
+	if cents < 0 {
+		return -int(-cents + 0.5)
+	}
+
+	return int(cents + 0.5)
+}
+
+// StreakDTO is an unbroken run of results with the same outcome.
+type StreakDTO struct {
+	Outcome string `json:"outcome" jsonschema:"winning or losing"`
+	Length  int    `json:"length" jsonschema:"the number of consecutive results in the run"`
+
+	NetCents   int    `json:"netCents" jsonschema:"the run's combined net result, in cents"`
+	NetDisplay string `json:"netDisplay" jsonschema:"the run's net preformatted in dollars; show this rather than converting netCents yourself"`
+
+	StartedAt time.Time `json:"startedAt" jsonschema:"when the first result in the run occurred"`
+	EndedAt   time.Time `json:"endedAt" jsonschema:"when the last result in the run occurred"`
+}
+
+// newStreak maps a model.Streak to a DTO, returning nil when there is no such run
+// so the field is omitted rather than reported as a zero-length streak.
+func newStreak(s model.Streak) *StreakDTO {
+	if s.Outcome == model.StreakNone || s.Length == 0 {
+		return nil
+	}
+
+	return &StreakDTO{
+		Outcome:    string(s.Outcome),
+		Length:     s.Length,
+		NetCents:   s.NetCents,
+		NetDisplay: money.FormatCents(s.NetCents),
+		StartedAt:  s.StartedAt,
+		EndedAt:    s.EndedAt,
+	}
+}
+
+// StreaksDTO summarizes the runs within a chronological series of results.
+type StreaksDTO struct {
+	LongestWinning *StreakDTO `json:"longestWinning,omitempty" jsonschema:"the longest run of consecutive winning results; absent when there was none"`
+	LongestLosing  *StreakDTO `json:"longestLosing,omitempty" jsonschema:"the longest run of consecutive losing results; absent when there was none"`
+	Current        *StreakDTO `json:"current,omitempty" jsonschema:"the run still in progress as of the most recent result; absent when the latest result broke even, which ends any run"`
+}
+
+// fromStreaks maps model.Streaks to a DTO.
+func fromStreaks(s model.Streaks) StreaksDTO {
+	return StreaksDTO{
+		LongestWinning: newStreak(s.LongestWinning),
+		LongestLosing:  newStreak(s.LongestLosing),
+		Current:        newStreak(s.Current),
+	}
+}
+
+// PlayerVarianceDTO is a player's consistency profile.
+type PlayerVarianceDTO struct {
+	ByGame    SpreadDTO `json:"byGame" jsonschema:"the distribution of the player's per-game results; this is the honest swing measure, having enough data points to mean something"`
+	BySession SpreadDTO `json:"bySession" jsonschema:"the distribution of the player's per-night results, a night being one table"`
+
+	GameStreaks    StreaksDTO `json:"gameStreaks" jsonschema:"runs of consecutive winning or losing games"`
+	SessionStreaks StreaksDTO `json:"sessionStreaks" jsonschema:"runs of consecutive winning or losing nights; this is the streak a player would talk about. A break-even night belongs to neither run and ends whichever was in progress"`
+}
+
+// fromPlayerVariance maps a model.PlayerVariance to a DTO.
+func fromPlayerVariance(v *model.PlayerVariance) PlayerVarianceDTO {
+	return PlayerVarianceDTO{
+		ByGame:         fromSpread(v.ByGame),
+		BySession:      fromSpread(v.BySession),
+		GameStreaks:    fromStreaks(v.GameStreaks),
+		SessionStreaks: fromStreaks(v.SessionStreaks),
+	}
+}

--- a/internal/mcpserver/dto_analytics.go
+++ b/internal/mcpserver/dto_analytics.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"mondaynightpoker-server/pkg/deck"
@@ -45,15 +46,6 @@ type CardDTO struct {
 	Display string `json:"display,omitempty" jsonschema:"the card preformatted for display; show this to the user. Omitted for a card whose suit is not recognized, which a hidden or placeholder card in an older log can be"`
 }
 
-// knownSuits are the suits deck.Card.String can render.
-var knownSuits = map[deck.Suit]bool{
-	deck.Hearts:   true,
-	deck.Clubs:    true,
-	deck.Diamonds: true,
-	deck.Spades:   true,
-	deck.Stars:    true,
-}
-
 // cardDisplay renders a card for display, returning an empty string rather than
 // letting deck.Card.String panic.
 //
@@ -63,7 +55,7 @@ var knownSuits = map[deck.Suit]bool{
 // on. Losing one display string is a fair trade for a tool that cannot be crashed
 // by a row in the database.
 func cardDisplay(c *deck.Card) string {
-	if !knownSuits[c.Suit] {
+	if !c.Suit.Valid() {
 		return ""
 	}
 
@@ -320,14 +312,11 @@ func fromSpread(s model.Spread) SpreadDTO {
 	}
 }
 
-// roundCents rounds a fractional cent amount to the nearest whole cent, halves
-// away from zero, for rendering through the shared money formatter.
+// roundCents rounds a fractional cent amount to the nearest whole cent for
+// rendering through the shared money formatter. math.Round rounds halves away
+// from zero, which is what the display wants in both directions.
 func roundCents(cents float64) int {
-	if cents < 0 {
-		return -int(-cents + 0.5)
-	}
-
-	return int(cents + 0.5)
+	return int(math.Round(cents))
 }
 
 // StreakDTO is an unbroken run of results with the same outcome.

--- a/internal/mcpserver/dto_analytics_test.go
+++ b/internal/mcpserver/dto_analytics_test.go
@@ -1,0 +1,121 @@
+package mcpserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/model"
+)
+
+func TestFromCards(t *testing.T) {
+	a := assert.New(t)
+
+	got := fromCards([]*deck.Card{
+		{Rank: 14, Suit: deck.Spades},
+		nil, // a card that was never dealt or is not visible to the caller
+		{Rank: 11, Suit: deck.Hearts, IsWild: true},
+	})
+
+	require.Len(t, got, 2, "nil cards are skipped")
+	a.Equal("A♠", got[0].Display)
+	a.False(got[0].IsWild)
+	a.Equal("J♡", got[1].Display)
+	a.True(got[1].IsWild)
+}
+
+// TestFromCards_UnknownSuit pins that a card the renderer cannot describe loses its
+// display string rather than panicking. These cards come out of persisted jsonb, so
+// nothing guarantees the suit is one deck.Card.String knows.
+func TestFromCards_UnknownSuit(t *testing.T) {
+	a := assert.New(t)
+
+	var got []CardDTO
+	a.NotPanics(func() {
+		got = fromCards([]*deck.Card{{Rank: 0, Suit: deck.Suit("")}, {Rank: 5, Suit: deck.Suit("swords")}})
+	})
+
+	require.Len(t, got, 2)
+	for _, c := range got {
+		a.Empty(c.Display, "an unrenderable card has no display string")
+	}
+	a.Equal("swords", got[1].Suit, "the raw suit is still reported")
+}
+
+func TestNewRate(t *testing.T) {
+	a := assert.New(t)
+
+	got := newRate(0.625, true)
+	require.NotNil(t, got)
+	a.Equal(0.625, got.Value)
+	a.Equal("62.5%", got.Display)
+
+	// An undefined statistic is absent rather than zero: "0.0%" would read as a
+	// real measurement.
+	a.Nil(newRate(0, false))
+}
+
+func TestRoundCents(t *testing.T) {
+	for in, want := range map[float64]int{
+		0:      0,
+		12.4:   12,
+		12.5:   13,
+		12.6:   13,
+		-12.4:  -12,
+		-12.5:  -13,
+		-12.6:  -13,
+		100.49: 100,
+	} {
+		assert.Equal(t, want, roundCents(in), "roundCents(%v)", in)
+	}
+}
+
+func TestFromSpread(t *testing.T) {
+	a := assert.New(t)
+
+	got := fromSpread(model.NewSpread([]int{100, -50, 25}))
+
+	a.Equal(3, got.Count)
+	a.Equal(75, got.TotalCents)
+	a.Equal("$0.75", got.TotalDisplay)
+	a.InDelta(25.0, got.MeanCents, 0.001)
+	a.Equal("$0.25", got.MeanDisplay)
+	a.Equal("$0.25", got.MedianDisplay)
+	a.Equal("$1", got.BestDisplay)
+	a.Equal("-$0.50", got.WorstDisplay)
+}
+
+func TestFromStreaks(t *testing.T) {
+	a := assert.New(t)
+
+	got := fromStreaks(model.ComputeStreaks([]model.StreakInput{
+		{NetCents: 100}, {NetCents: 50}, {NetCents: -20},
+	}))
+
+	require.NotNil(t, got.LongestWinning)
+	a.Equal("winning", got.LongestWinning.Outcome)
+	a.Equal(2, got.LongestWinning.Length)
+	a.Equal("$1.50", got.LongestWinning.NetDisplay)
+
+	require.NotNil(t, got.LongestLosing)
+	a.Equal(1, got.LongestLosing.Length)
+
+	require.NotNil(t, got.Current)
+	a.Equal("losing", got.Current.Outcome)
+}
+
+// TestFromStreaks_Absent pins that a run that never happened is omitted rather than
+// reported as a zero-length streak.
+func TestFromStreaks_Absent(t *testing.T) {
+	a := assert.New(t)
+
+	got := fromStreaks(model.ComputeStreaks([]model.StreakInput{{NetCents: 100}}))
+
+	a.NotNil(got.LongestWinning)
+	a.Nil(got.LongestLosing, "never lost, so there is no losing streak")
+	a.NotNil(got.Current)
+
+	a.Nil(fromStreaks(model.ComputeStreaks(nil)).Current)
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -169,3 +169,41 @@ func (s *server) activeTable(ctx context.Context, uuid string) (*model.Table, er
 
 	return table, nil
 }
+
+// gameAtTable resolves a game that belongs to the given table, and is the single
+// place that enforces the capability rule for games.
+//
+// The table uuid is the capability. games.id is sequential, so keying on the id
+// alone would let any authenticated caller walk the id space and read every game
+// site-wide; a game is only returned when it actually belongs to the table whose
+// uuid the caller presented. Every outcome — an unknown or soft-deleted table, an
+// unknown game, or a game at some other table — reports "game not found"
+// identically, so a caller cannot probe which part of the request was wrong or
+// learn that a game with this id exists elsewhere.
+//
+// withData controls whether the (potentially large) jsonb log is fetched.
+// Routing every game lookup through here means a new tool cannot forget the
+// ownership comparison, the same way activeTable keeps one from forgetting the
+// deleted check.
+func (s *server) gameAtTable(ctx context.Context, uuid string, id int64, withData bool) (*model.Game, error) {
+	table, err := s.activeTable(ctx, uuid)
+	if err != nil {
+		return nil, errNotFound("game")
+	}
+
+	var game *model.Game
+	if withData {
+		game, err = s.repos.Games.GetGameByID(ctx, id)
+	} else {
+		game, err = s.repos.Games.GetGameByIDNoData(ctx, id)
+	}
+	if err != nil {
+		return nil, errNotFound("game")
+	}
+
+	if game.TableUUID != table.UUID {
+		return nil, errNotFound("game")
+	}
+
+	return game, nil
+}

--- a/internal/mcpserver/register_test.go
+++ b/internal/mcpserver/register_test.go
@@ -164,6 +164,9 @@ var expectedPolicies = map[string]accessPolicy{
 	"list_player_transactions": accessSelfScoped,
 	"leaderboard":              accessAuthenticated,
 	"list_game_types":          accessAuthenticated,
+	"get_hand_history":         accessAuthenticated,
+	"get_player_tendencies":    accessSelfScoped,
+	"get_player_variance":      accessSelfScoped,
 }
 
 func TestRegistry_MatchesExpectedPolicies(t *testing.T) {

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -536,32 +536,12 @@ type getGameInput struct {
 }
 
 func (s *server) getGame(ctx context.Context, _ *mcp.CallToolRequest, _ oauth.Caller, in getGameInput) (GameDTO, error) {
-	// Resolve the table first: this both rejects soft-deleted/absent tables and pins the
-	// caller to the capability they hold. A caller who was never given this uuid cannot
-	// reach the game regardless of how they guessed its (sequential) id.
-	table, err := s.activeTable(ctx, in.UUID)
-	if err != nil {
-		return GameDTO{}, errNotFound("game")
-	}
-
 	// Only fetch the (potentially large) jsonb log when the caller asked for it.
 	includeLog := in.IncludeLog != nil && *in.IncludeLog
 
-	var game *model.Game
-	if includeLog {
-		game, err = s.repos.Games.GetGameByID(ctx, in.ID)
-	} else {
-		game, err = s.repos.Games.GetGameByIDNoData(ctx, in.ID)
-	}
+	game, err := s.gameAtTable(ctx, in.UUID, in.ID, includeLog)
 	if err != nil {
-		// A missing game and a game belonging to another table are reported identically,
-		// so a caller cannot probe which part of the request was wrong (or learn that a
-		// game with this id exists at some other table).
-		return GameDTO{}, errNotFound("game")
-	}
-
-	if game.TableUUID != table.UUID {
-		return GameDTO{}, errNotFound("game")
+		return GameDTO{}, err
 	}
 
 	adjustments, err := s.repos.Games.GetGameAdjustments(ctx, []int64{game.ID})

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -94,6 +94,21 @@ func (s *server) registerTools(m *mcp.Server) {
 		Name:        "list_game_types",
 		Description: "List the registered game types, each with its canonical display group.",
 	}, accessAuthenticated, s.listGameTypes)
+
+	registerTool(s, m, &mcp.Tool{
+		Name:        "get_hand_history",
+		Description: "Get a single game's log decoded into a normalized hand: every player's cards and outcome plus the ordered list of actions they took. Unlike get_game with includeLog, the shape is the same for every game type, so hands can be read and compared without knowing each game's own log format. The table uuid is the capability: a game is only returned when it belongs to that table. Available to any authenticated player (capability-URL semantics).",
+	}, accessAuthenticated, s.getHandHistory)
+
+	registerTool(s, m, &mcp.Tool{
+		Name:        "get_player_tendencies",
+		Description: "Get a player's behavioral profile within an optional date range, derived from game logs rather than the ledger: how often they voluntarily played, folded, reached a showdown and won there, plus their aggression factor and action counts, overall and per game type. This is the counterpart to get_player_stats, which reports how much they won rather than how they played. Non-admin callers may only request their own player id.",
+	}, accessSelfScoped, s.getPlayerTendencies)
+
+	registerTool(s, m, &mcp.Tool{
+		Name:        "get_player_variance",
+		Description: "Get a player's consistency profile within an optional date range: the spread of their results (mean, median, standard deviation, best and worst) per game and per night, plus their longest winning and losing streaks and any streak currently running. Use this to tell whether a player's total reflects steady results or big swings. Non-admin callers may only request their own player id.",
+	}, accessSelfScoped, s.getPlayerVariance)
 }
 
 // whoamiInput is the (empty) input for the whoami tool. It deliberately takes no player

--- a/internal/mcpserver/tools_analytics.go
+++ b/internal/mcpserver/tools_analytics.go
@@ -2,7 +2,6 @@ package mcpserver
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -39,26 +38,12 @@ type getHandHistoryOutput struct {
 // another table, and a game whose log cannot be read are reported identically so a
 // caller cannot probe which part of the request was wrong.
 func (s *server) getHandHistory(ctx context.Context, _ *mcp.CallToolRequest, _ oauth.Caller, in getHandHistoryInput) (getHandHistoryOutput, error) {
-	table, err := s.activeTable(ctx, in.UUID)
-	if err != nil {
-		return getHandHistoryOutput{}, errNotFound("game")
-	}
-
-	game, err := s.repos.Games.GetGameByID(ctx, in.ID)
-	if err != nil {
-		return getHandHistoryOutput{}, errNotFound("game")
-	}
-
-	if game.TableUUID != table.UUID {
-		return getHandHistoryOutput{}, errNotFound("game")
-	}
-
-	raw, err := rawGameData(game)
+	game, err := s.gameAtTable(ctx, in.UUID, in.ID, true)
 	if err != nil {
 		return getHandHistoryOutput{}, err
 	}
 
-	hand, err := gamefactory.ParseStoredGameLog(game.GameType, raw)
+	hand, err := gamefactory.ParseStoredGameLog(game.GameType, game.RawData())
 	if err != nil {
 		return getHandHistoryOutput{}, err
 	}
@@ -76,19 +61,6 @@ func (s *server) getHandHistory(ctx context.Context, _ *mcp.CallToolRequest, _ o
 	names, nets := adjustmentLookups(adjustments[game.ID])
 
 	return getHandHistoryOutput{Hand: fromHand(hand, game, names, nets)}, nil
-}
-
-// rawGameData re-encodes a game's decoded jsonb payload back into JSON for the
-// parsers. model.Game unmarshals the column into an interface{}, so this is a
-// round trip rather than the original bytes; it is faithful because the value came
-// from encoding/json in the first place.
-func rawGameData(game *model.Game) (json.RawMessage, error) {
-	data := game.Data()
-	if data == nil {
-		return nil, nil
-	}
-
-	return json.Marshal(data)
 }
 
 // adjustmentLookups turns a game's ledger rows into display-name and net lookups
@@ -122,8 +94,8 @@ type getPlayerTendenciesOutput struct {
 	ByGameType map[string]TendenciesDTO `json:"byGameType" jsonschema:"the same profile broken out per game-type identifier; the numbers are only comparable across game types for the poker variants, since games without a betting round have no true equivalent of a call or a raise"`
 
 	GamesAnalyzed int   `json:"gamesAnalyzed" jsonschema:"the number of game logs successfully parsed"`
-	GamesInRange  int64 `json:"gamesInRange" jsonschema:"the total number of the player's completed games in the range, ignoring the analysis cap"`
-	Truncated     bool  `json:"truncated" jsonschema:"whether the range held more games than were analyzed; when true only the most recent games are reflected and the rates describe that subset"`
+	GamesInRange  int64 `json:"gamesInRange" jsonschema:"the total number of the player's completed games in the range, ignoring the analysis cap. It counts every game type even when gameType narrows the analysis, so with a filter set it will normally exceed gamesAnalyzed"`
+	Truncated     bool  `json:"truncated" jsonschema:"whether the range held more games than could be examined; when true only the most recent games are reflected and the rates describe that subset. With gameType set this is computed before the filter, so a true value means the filtered profile may also be missing older matching games"`
 	GamesSkipped  int   `json:"gamesSkipped" jsonschema:"game logs that could not be parsed and were left out; a non-zero value means those games are missing from every figure here"`
 }
 
@@ -160,12 +132,7 @@ func (s *server) getPlayerTendencies(ctx context.Context, _ *mcp.CallToolRequest
 		gameTypeFilter = *in.GameType
 	}
 
-	records, err := s.repos.Players.GetPlayerGameLogs(ctx, in.ID, from, to, maxAnalyzedGameLogs)
-	if err != nil {
-		return getPlayerTendenciesOutput{}, err
-	}
-
-	total, err := s.repos.Players.GetPlayerGameLogsCount(ctx, in.ID, from, to)
+	records, total, err := s.repos.Players.GetPlayerGameLogs(ctx, in.ID, from, to, maxAnalyzedGameLogs)
 	if err != nil {
 		return getPlayerTendenciesOutput{}, err
 	}
@@ -176,17 +143,23 @@ func (s *server) getPlayerTendencies(ctx context.Context, _ *mcp.CallToolRequest
 	skipped := 0
 
 	for _, rec := range records {
+		// Resolve the stored display name before decoding: the filter is decidable
+		// from it alone, so a filtered request skips the jsonb parse for every game
+		// of another type instead of decoding it and throwing the result away.
+		if gameTypeFilter != "" {
+			name, err := gamefactory.NameForStoredGameType(rec.GameType)
+			if err != nil || name != gameTypeFilter {
+				continue
+			}
+		}
+
 		hand, err := gamefactory.ParseStoredGameLog(rec.GameType, rec.Data)
 		if err != nil || hand == nil {
 			skipped++
 			continue
 		}
 
-		if gameTypeFilter != "" && hand.GameType != gameTypeFilter {
-			continue
-		}
-
-		participation := findParticipation(hand, in.ID)
+		participation := hand.FindParticipant(in.ID)
 		if participation == nil {
 			// The ledger says the player was in this game but the log does not
 			// name them, so there is nothing to attribute.
@@ -220,18 +193,6 @@ func (s *server) getPlayerTendencies(ctx context.Context, _ *mcp.CallToolRequest
 	}
 
 	return out, nil
-}
-
-// findParticipation returns the player's participation record within the hand, or
-// nil when the log does not name them.
-func findParticipation(hand *gamelog.Hand, playerID int64) *gamelog.Participation {
-	for _, p := range hand.Participants {
-		if p.PlayerID == playerID {
-			return p
-		}
-	}
-
-	return nil
 }
 
 // getPlayerVarianceInput is the input for the get_player_variance tool.

--- a/internal/mcpserver/tools_analytics.go
+++ b/internal/mcpserver/tools_analytics.go
@@ -96,7 +96,7 @@ type getPlayerTendenciesOutput struct {
 	GamesAnalyzed int   `json:"gamesAnalyzed" jsonschema:"the number of game logs successfully parsed"`
 	GamesInRange  int64 `json:"gamesInRange" jsonschema:"the total number of the player's completed games in the range, ignoring the analysis cap. It counts every game type even when gameType narrows the analysis, so with a filter set it will normally exceed gamesAnalyzed"`
 	Truncated     bool  `json:"truncated" jsonschema:"whether the range held more games than could be examined; when true only the most recent games are reflected and the rates describe that subset. With gameType set this is computed before the filter, so a true value means the filtered profile may also be missing older matching games"`
-	GamesSkipped  int   `json:"gamesSkipped" jsonschema:"game logs that could not be parsed and were left out; a non-zero value means those games are missing from every figure here"`
+	GamesSkipped  int   `json:"gamesSkipped" jsonschema:"game logs left out of the analysis, either because the stored log could not be parsed or because it parsed fine but did not name this player (a ledger/log disagreement); a non-zero value means those games are missing from every figure here"`
 }
 
 // getPlayerTendencies aggregates a player's decisions across their game logs.

--- a/internal/mcpserver/tools_analytics.go
+++ b/internal/mcpserver/tools_analytics.go
@@ -1,0 +1,279 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"mondaynightpoker-server/internal/oauth"
+	"mondaynightpoker-server/pkg/model"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+	"mondaynightpoker-server/pkg/room/gamefactory"
+)
+
+// maxAnalyzedGameLogs bounds how many game logs a single tendencies call parses.
+//
+// Every log is decoded in memory, so an unbounded range on a long-running table
+// would be paced by the jsonb rather than by the caller. When the range holds more
+// games than this, the most recent ones are analyzed and the response says so
+// rather than quietly presenting a partial answer as complete.
+const maxAnalyzedGameLogs = 500
+
+// getHandHistoryInput is the input for the get_hand_history tool.
+type getHandHistoryInput struct {
+	UUID string `json:"uuid" jsonschema:"the table's uuid"`
+	ID   int64  `json:"id" jsonschema:"the game's numeric id"`
+}
+
+// getHandHistoryOutput is the output for the get_hand_history tool.
+type getHandHistoryOutput struct {
+	Hand HandDTO `json:"hand" jsonschema:"the normalized hand"`
+}
+
+// getHandHistory returns a single game's log decoded into the normalized hand
+// shape, rather than the raw game-specific payload get_game exposes.
+//
+// Authorization matches get_game exactly: the table uuid is the capability, and a
+// game is only returned when it belongs to that table. A missing game, a game at
+// another table, and a game whose log cannot be read are reported identically so a
+// caller cannot probe which part of the request was wrong.
+func (s *server) getHandHistory(ctx context.Context, _ *mcp.CallToolRequest, _ oauth.Caller, in getHandHistoryInput) (getHandHistoryOutput, error) {
+	table, err := s.activeTable(ctx, in.UUID)
+	if err != nil {
+		return getHandHistoryOutput{}, errNotFound("game")
+	}
+
+	game, err := s.repos.Games.GetGameByID(ctx, in.ID)
+	if err != nil {
+		return getHandHistoryOutput{}, errNotFound("game")
+	}
+
+	if game.TableUUID != table.UUID {
+		return getHandHistoryOutput{}, errNotFound("game")
+	}
+
+	raw, err := rawGameData(game)
+	if err != nil {
+		return getHandHistoryOutput{}, err
+	}
+
+	hand, err := gamefactory.ParseStoredGameLog(game.GameType, raw)
+	if err != nil {
+		return getHandHistoryOutput{}, err
+	}
+	if hand == nil {
+		// The game row exists but never received a log, which is what an
+		// in-progress or terminated game looks like.
+		return getHandHistoryOutput{}, errNotFound("hand history")
+	}
+
+	adjustments, err := s.repos.Games.GetGameAdjustments(ctx, []int64{game.ID})
+	if err != nil {
+		return getHandHistoryOutput{}, err
+	}
+
+	names, nets := adjustmentLookups(adjustments[game.ID])
+
+	return getHandHistoryOutput{Hand: fromHand(hand, game, names, nets)}, nil
+}
+
+// rawGameData re-encodes a game's decoded jsonb payload back into JSON for the
+// parsers. model.Game unmarshals the column into an interface{}, so this is a
+// round trip rather than the original bytes; it is faithful because the value came
+// from encoding/json in the first place.
+func rawGameData(game *model.Game) (json.RawMessage, error) {
+	data := game.Data()
+	if data == nil {
+		return nil, nil
+	}
+
+	return json.Marshal(data)
+}
+
+// adjustmentLookups turns a game's ledger rows into display-name and net lookups
+// keyed by player id.
+func adjustmentLookups(adjustments []*model.GameAdjustment) (names map[int64]string, nets map[int64]int) {
+	names = make(map[int64]string, len(adjustments))
+	nets = make(map[int64]int, len(adjustments))
+	for _, a := range adjustments {
+		names[a.PlayerID] = a.DisplayName
+		nets[a.PlayerID] = a.Adjustment
+	}
+
+	return names, nets
+}
+
+// getPlayerTendenciesInput is the input for the get_player_tendencies tool.
+type getPlayerTendenciesInput struct {
+	ID       int64   `json:"id" jsonschema:"the player's numeric id"`
+	From     *string `json:"from,omitempty" jsonschema:"optional start of the date range (RFC3339); defaults to the epoch"`
+	To       *string `json:"to,omitempty" jsonschema:"optional end of the date range (RFC3339); defaults to now"`
+	GameType *string `json:"gameType,omitempty" jsonschema:"optional game-type identifier to restrict the analysis to, as returned by list_game_types (e.g. texas-hold-em); when omitted every game type is included"`
+}
+
+func (in getPlayerTendenciesInput) targetPlayerID() int64 { return in.ID }
+
+// getPlayerTendenciesOutput is the output for the get_player_tendencies tool.
+type getPlayerTendenciesOutput struct {
+	Player     PlayerDTO     `json:"player" jsonschema:"the player"`
+	Tendencies TendenciesDTO `json:"tendencies" jsonschema:"the player's aggregate behavioral profile across every analyzed hand"`
+
+	ByGameType map[string]TendenciesDTO `json:"byGameType" jsonschema:"the same profile broken out per game-type identifier; the numbers are only comparable across game types for the poker variants, since games without a betting round have no true equivalent of a call or a raise"`
+
+	GamesAnalyzed int   `json:"gamesAnalyzed" jsonschema:"the number of game logs successfully parsed"`
+	GamesInRange  int64 `json:"gamesInRange" jsonschema:"the total number of the player's completed games in the range, ignoring the analysis cap"`
+	Truncated     bool  `json:"truncated" jsonschema:"whether the range held more games than were analyzed; when true only the most recent games are reflected and the rates describe that subset"`
+	GamesSkipped  int   `json:"gamesSkipped" jsonschema:"game logs that could not be parsed and were left out; a non-zero value means those games are missing from every figure here"`
+}
+
+// getPlayerTendencies aggregates a player's decisions across their game logs.
+//
+// This is the behavioral counterpart to get_player_stats: the ledger already says
+// how much someone won, and this says how they played. Every figure is derived
+// from the persisted logs rather than the ledger, so games that never finished
+// contribute nothing.
+//
+// A log that fails to parse is counted in GamesSkipped rather than failing the
+// call. One malformed or newer-format payload should not make a player's whole
+// history unreadable, but the count is surfaced so a caller can tell the
+// difference between a complete answer and a partial one.
+func (s *server) getPlayerTendencies(ctx context.Context, _ *mcp.CallToolRequest, caller oauth.Caller, in getPlayerTendenciesInput) (getPlayerTendenciesOutput, error) {
+	from, to, err := parseDateRange(in.From, in.To)
+	if err != nil {
+		return getPlayerTendenciesOutput{}, err
+	}
+
+	player, err := s.repos.Players.GetPlayerByID(ctx, in.ID)
+	if err != nil {
+		return getPlayerTendenciesOutput{}, notFound(err, "player")
+	}
+
+	// Reject an unknown game type outright rather than silently returning an empty
+	// profile, which would read as "this player has never played it".
+	var gameTypeFilter string
+	if in.GameType != nil && *in.GameType != "" {
+		if _, err := gamefactory.Get(*in.GameType); err != nil {
+			return getPlayerTendenciesOutput{}, err
+		}
+
+		gameTypeFilter = *in.GameType
+	}
+
+	records, err := s.repos.Players.GetPlayerGameLogs(ctx, in.ID, from, to, maxAnalyzedGameLogs)
+	if err != nil {
+		return getPlayerTendenciesOutput{}, err
+	}
+
+	total, err := s.repos.Players.GetPlayerGameLogsCount(ctx, in.ID, from, to)
+	if err != nil {
+		return getPlayerTendenciesOutput{}, err
+	}
+
+	var overall gamelog.Tendencies
+	byGameType := make(map[string]*gamelog.Tendencies)
+	analyzed := 0
+	skipped := 0
+
+	for _, rec := range records {
+		hand, err := gamefactory.ParseStoredGameLog(rec.GameType, rec.Data)
+		if err != nil || hand == nil {
+			skipped++
+			continue
+		}
+
+		if gameTypeFilter != "" && hand.GameType != gameTypeFilter {
+			continue
+		}
+
+		participation := findParticipation(hand, in.ID)
+		if participation == nil {
+			// The ledger says the player was in this game but the log does not
+			// name them, so there is nothing to attribute.
+			skipped++
+			continue
+		}
+
+		analyzed++
+		overall.Add(participation)
+
+		perType, ok := byGameType[hand.GameType]
+		if !ok {
+			perType = &gamelog.Tendencies{}
+			byGameType[hand.GameType] = perType
+		}
+		perType.Add(participation)
+	}
+
+	out := getPlayerTendenciesOutput{
+		Player:        fromPlayer(player, caller),
+		Tendencies:    fromTendencies(&overall),
+		ByGameType:    make(map[string]TendenciesDTO, len(byGameType)),
+		GamesAnalyzed: analyzed,
+		GamesInRange:  total,
+		Truncated:     total > int64(len(records)),
+		GamesSkipped:  skipped,
+	}
+
+	for gameType, t := range byGameType {
+		out.ByGameType[gameType] = fromTendencies(t)
+	}
+
+	return out, nil
+}
+
+// findParticipation returns the player's participation record within the hand, or
+// nil when the log does not name them.
+func findParticipation(hand *gamelog.Hand, playerID int64) *gamelog.Participation {
+	for _, p := range hand.Participants {
+		if p.PlayerID == playerID {
+			return p
+		}
+	}
+
+	return nil
+}
+
+// getPlayerVarianceInput is the input for the get_player_variance tool.
+type getPlayerVarianceInput struct {
+	ID   int64   `json:"id" jsonschema:"the player's numeric id"`
+	From *string `json:"from,omitempty" jsonschema:"optional start of the date range (RFC3339); defaults to the epoch"`
+	To   *string `json:"to,omitempty" jsonschema:"optional end of the date range (RFC3339); defaults to now"`
+}
+
+func (in getPlayerVarianceInput) targetPlayerID() int64 { return in.ID }
+
+// getPlayerVarianceOutput is the output for the get_player_variance tool.
+type getPlayerVarianceOutput struct {
+	Player   PlayerDTO         `json:"player" jsonschema:"the player"`
+	Variance PlayerVarianceDTO `json:"variance" jsonschema:"the player's spread and streaks"`
+}
+
+// getPlayerVariance reports how consistent a player's results are, at both game
+// and night granularity.
+//
+// get_player_stats answers how much someone is up; this answers whether that
+// number means anything. Two players up the same amount look identical until you
+// see that one ground it out and the other swung wildly in both directions, and
+// the standard deviation is what separates them.
+func (s *server) getPlayerVariance(ctx context.Context, _ *mcp.CallToolRequest, caller oauth.Caller, in getPlayerVarianceInput) (getPlayerVarianceOutput, error) {
+	from, to, err := parseDateRange(in.From, in.To)
+	if err != nil {
+		return getPlayerVarianceOutput{}, err
+	}
+
+	player, err := s.repos.Players.GetPlayerByID(ctx, in.ID)
+	if err != nil {
+		return getPlayerVarianceOutput{}, notFound(err, "player")
+	}
+
+	variance, err := s.repos.Players.GetPlayerVariance(ctx, in.ID, from, to)
+	if err != nil {
+		return getPlayerVarianceOutput{}, err
+	}
+
+	return getPlayerVarianceOutput{
+		Player:   fromPlayer(player, caller),
+		Variance: fromPlayerVariance(variance),
+	}, nil
+}

--- a/internal/mcpserver/tools_analytics_test.go
+++ b/internal/mcpserver/tools_analytics_test.go
@@ -1,0 +1,440 @@
+package mcpserver
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mondaynightpoker-server/pkg/model"
+)
+
+// holdEmLog is a persisted Texas Hold'em log in the shape the game writes: the
+// action and variant enums are objects because their MarshalJSON emits
+// {"id","name"}. Building it as a literal keeps these tests independent of the
+// game packages while still exercising the real on-disk encoding.
+func holdEmLog(winnerID, loserID int64) map[string]interface{} {
+	return map[string]interface{}{
+		"variant":    map[string]interface{}{"id": "standard", "name": "Standard"},
+		"ante":       0,
+		"smallBlind": 25,
+		"bigBlind":   50,
+		"pot":        300,
+		"community": []interface{}{
+			map[string]interface{}{"rank": 14, "suit": "spades"},
+			map[string]interface{}{"rank": 7, "suit": "diamonds"},
+			map[string]interface{}{"rank": 2, "suit": "clubs"},
+		},
+		"seats": []interface{}{
+			map[string]interface{}{"playerId": winnerID, "holeCards": []interface{}{map[string]interface{}{"rank": 13, "suit": "spades"}}},
+			map[string]interface{}{"playerId": loserID, "holeCards": []interface{}{map[string]interface{}{"rank": 3, "suit": "clubs"}}},
+		},
+		"actions": []interface{}{
+			map[string]interface{}{"street": "preflop", "playerId": winnerID, "action": map[string]interface{}{"id": "raise", "name": "Raise"}, "amount": 150},
+			map[string]interface{}{"street": "preflop", "playerId": loserID, "action": map[string]interface{}{"id": "call", "name": "Call"}, "amount": 150},
+			map[string]interface{}{"street": "flop", "playerId": winnerID, "action": map[string]interface{}{"id": "bet", "name": "Bet"}, "amount": 100},
+			map[string]interface{}{"street": "flop", "playerId": loserID, "action": map[string]interface{}{"id": "fold", "name": "Fold"}},
+		},
+		"participants": []interface{}{
+			map[string]interface{}{"playerId": winnerID, "winnings": 300},
+			map[string]interface{}{"playerId": loserID, "folded": true},
+		},
+	}
+}
+
+// endHoldEmGame creates and ends a Texas Hold'em game at the table, storing a real
+// log. The stored game_type is a display name, which is what the column actually
+// holds and what the parser dispatch has to resolve.
+func endHoldEmGame(t *testing.T, tbl *model.Table, winnerID, loserID int64, adjustments map[int64]int) *model.Game {
+	t.Helper()
+
+	game, err := testRepos.Games.CreateGame(cbg, tbl, "Texas Hold'em")
+	require.NoError(t, err)
+	require.NoError(t, testRepos.Games.EndGame(cbg, game, holdEmLog(winnerID, loserID), adjustments))
+
+	return game
+}
+
+func TestGetHandHistory(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	other := createPlayer(t)
+
+	tbl, err := testRepos.Tables.CreateTable(cbg, admin, "Hand History Table")
+	a.NoError(err)
+	_, err = testRepos.Tables.Join(cbg, other, tbl)
+	a.NoError(err)
+
+	game := endHoldEmGame(t, tbl, admin.ID, other.ID, map[int64]int{admin.ID: 150, other.ID: -150})
+
+	// The table uuid is the capability, so any authenticated player holding it may
+	// read the hand — same rule as get_game.
+	outsider := createPlayer(t)
+	out, err := s.getHandHistory(cbg, nil, playerCaller(outsider.ID), getHandHistoryInput{UUID: tbl.UUID, ID: game.ID})
+	require.NoError(t, err)
+
+	hand := out.Hand
+	a.Equal(game.ID, hand.GameID)
+	a.Equal("texas-hold-em", hand.GameType, "the display name resolves to a factory identifier")
+	a.Equal("Texas Hold'em", hand.StoredGameType)
+	a.Equal("standard", hand.Variant)
+	a.Equal(300, hand.PotCents)
+	require.Len(t, hand.Board, 3)
+	a.Equal("A♠", hand.Board[0].Display)
+	a.Equal("spades", hand.Board[0].Suit)
+	a.Equal(14, hand.Board[0].Rank)
+	a.Len(hand.Actions, 4)
+
+	// Display names and net results come from the ledger, not the log.
+	require.Len(t, hand.Participants, 2)
+	byID := map[int64]HandParticipantDTO{}
+	for _, p := range hand.Participants {
+		byID[p.PlayerID] = p
+	}
+
+	winner := byID[admin.ID]
+	a.True(winner.VoluntarilyPlayed)
+	a.True(winner.Won)
+	a.False(winner.WentToShowdown, "the opponent folded, so nothing was shown down")
+	a.Equal(250, winner.AmountWageredCents)
+	require.NotNil(t, winner.NetCents)
+	a.Equal(150, *winner.NetCents)
+	require.NotNil(t, winner.NetDisplay)
+	a.Equal("$1.50", *winner.NetDisplay)
+	a.NotEmpty(winner.DisplayName)
+
+	loser := byID[other.ID]
+	a.True(loser.Folded)
+	a.True(loser.VoluntarilyPlayed, "called before folding later")
+	require.NotNil(t, loser.NetCents)
+	a.Equal(-150, *loser.NetCents)
+
+	// Actions are normalized and ordered.
+	a.Equal("raise", hand.Actions[0].Kind)
+	a.Equal("$1.50", hand.Actions[0].AmountDisplay)
+	a.Equal("fold", hand.Actions[3].Kind)
+	a.Equal(3, hand.Actions[3].Sequence)
+}
+
+// TestGetHandHistory_WrongTableIsNotFound is the enumeration guard: games.id is
+// sequential, so the table uuid has to be the capability here exactly as it is for
+// get_game.
+func TestGetHandHistory_WrongTableIsNotFound(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+
+	owner, err := testRepos.Tables.CreateTable(cbg, admin, "Owner Table")
+	a.NoError(err)
+	game := endHoldEmGame(t, owner, admin.ID, admin.ID, map[int64]int{admin.ID: 100})
+
+	other, err := testRepos.Tables.CreateTable(cbg, admin, "Other Table")
+	a.NoError(err)
+
+	_, err = s.getHandHistory(cbg, nil, adminCaller(admin.ID), getHandHistoryInput{UUID: other.UUID, ID: game.ID})
+	a.Error(err)
+	a.Contains(err.Error(), "game not found")
+
+	// An unknown table uuid reports the game missing, never the table: the response
+	// must not confirm the game exists.
+	_, err = s.getHandHistory(cbg, nil, adminCaller(admin.ID), getHandHistoryInput{UUID: uuid.New().String(), ID: game.ID})
+	a.Error(err)
+	a.Contains(err.Error(), "game not found")
+
+	_, err = s.getHandHistory(cbg, nil, adminCaller(admin.ID), getHandHistoryInput{UUID: owner.UUID, ID: -999})
+	a.Error(err)
+	a.Contains(err.Error(), "game not found")
+}
+
+func TestGetHandHistory_DeletedTableIsNotFound(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, admin, "Doomed Table")
+	a.NoError(err)
+	game := endHoldEmGame(t, tbl, admin.ID, admin.ID, map[int64]int{admin.ID: 100})
+
+	tbl.Deleted = true
+	a.NoError(testRepos.Tables.Save(cbg, tbl))
+
+	_, err = s.getHandHistory(cbg, nil, adminCaller(admin.ID), getHandHistoryInput{UUID: tbl.UUID, ID: game.ID})
+	a.Error(err)
+	a.Contains(err.Error(), "game not found")
+}
+
+// TestGetHandHistory_UnfinishedGame covers a game row created but never ended: it
+// has no log, so there is no hand to return.
+func TestGetHandHistory_UnfinishedGame(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, admin, "Unfinished Table")
+	a.NoError(err)
+
+	game, err := testRepos.Games.CreateGame(cbg, tbl, "Texas Hold'em")
+	a.NoError(err)
+
+	_, err = s.getHandHistory(cbg, nil, adminCaller(admin.ID), getHandHistoryInput{UUID: tbl.UUID, ID: game.ID})
+	a.Error(err)
+	a.Contains(err.Error(), "hand history not found")
+}
+
+func TestGetPlayerTendencies(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	other := createPlayer(t)
+
+	tbl, err := testRepos.Tables.CreateTable(cbg, admin, "Tendencies Table")
+	a.NoError(err)
+	_, err = testRepos.Tables.Join(cbg, other, tbl)
+	a.NoError(err)
+
+	// Two identical hands: admin raises and bets, other calls then folds.
+	endHoldEmGame(t, tbl, admin.ID, other.ID, map[int64]int{admin.ID: 150, other.ID: -150})
+	endHoldEmGame(t, tbl, admin.ID, other.ID, map[int64]int{admin.ID: 150, other.ID: -150})
+
+	out, err := s.getPlayerTendencies(cbg, nil, adminCaller(admin.ID), getPlayerTendenciesInput{ID: admin.ID})
+	require.NoError(t, err)
+
+	a.Equal(admin.ID, out.Player.ID)
+	a.Equal(2, out.GamesAnalyzed)
+	a.Equal(int64(2), out.GamesInRange)
+	a.False(out.Truncated)
+	a.Zero(out.GamesSkipped)
+
+	tend := out.Tendencies
+	a.Equal(2, tend.HandsAnalyzed)
+	a.Equal(2, tend.HandsVoluntarilyPlayed)
+	a.Equal(2, tend.HandsWon)
+	a.Zero(tend.HandsFolded)
+	a.Equal(2, tend.Raises)
+	a.Equal(2, tend.Bets)
+	a.Zero(tend.Calls)
+	a.Equal(500, tend.AmountWageredCents)
+
+	require.NotNil(t, tend.VoluntaryPlayRate)
+	a.Equal(1.0, tend.VoluntaryPlayRate.Value)
+	a.Equal("100.0%", tend.VoluntaryPlayRate.Display)
+
+	// Never called, so the aggression factor is undefined rather than infinite.
+	a.Nil(tend.AggressionFactor, "dividing by zero calls would report infinite aggression")
+
+	// Never reached a showdown, so that rate is absent rather than a misleading 0%.
+	a.Zero(tend.HandsToShowdown)
+	a.Nil(tend.ShowdownWinRate)
+
+	// The per-game-type breakdown is keyed by factory identifier.
+	require.Contains(t, out.ByGameType, "texas-hold-em")
+	a.Equal(2, out.ByGameType["texas-hold-em"].HandsAnalyzed)
+
+	// The other player called and folded, which is a different profile from the
+	// same hands.
+	out, err = s.getPlayerTendencies(cbg, nil, adminCaller(admin.ID), getPlayerTendenciesInput{ID: other.ID})
+	require.NoError(t, err)
+
+	tend = out.Tendencies
+	a.Equal(2, tend.HandsAnalyzed)
+	a.Equal(2, tend.HandsFolded)
+	a.Equal(2, tend.Calls)
+	a.Zero(tend.HandsWon)
+
+	require.NotNil(t, tend.AggressionFactor)
+	a.Zero(*tend.AggressionFactor, "called twice, never bet or raised")
+
+	require.NotNil(t, tend.FoldRate)
+	a.Equal("100.0%", tend.FoldRate.Display)
+}
+
+func TestGetPlayerTendencies_GameTypeFilter(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, admin, "Filter Table")
+	a.NoError(err)
+
+	endHoldEmGame(t, tbl, admin.ID, admin.ID, map[int64]int{admin.ID: 150})
+
+	out, err := s.getPlayerTendencies(cbg, nil, adminCaller(admin.ID),
+		getPlayerTendenciesInput{ID: admin.ID, GameType: ptrStr("texas-hold-em")})
+	require.NoError(t, err)
+	a.Equal(1, out.Tendencies.HandsAnalyzed)
+
+	// A game type the player has not played yields an empty profile, not an error.
+	out, err = s.getPlayerTendencies(cbg, nil, adminCaller(admin.ID),
+		getPlayerTendenciesInput{ID: admin.ID, GameType: ptrStr("bourre")})
+	require.NoError(t, err)
+	a.Zero(out.Tendencies.HandsAnalyzed)
+
+	// An unknown game type is an error rather than an empty profile, which would
+	// read as "this player has never played it".
+	_, err = s.getPlayerTendencies(cbg, nil, adminCaller(admin.ID),
+		getPlayerTendenciesInput{ID: admin.ID, GameType: ptrStr("go-fish")})
+	a.Error(err)
+	a.Contains(err.Error(), "no factory with name: go-fish")
+}
+
+// TestGetPlayerTendencies_SkipsUnparsableLogs pins that one unreadable payload does
+// not fail the call or vanish silently.
+func TestGetPlayerTendencies_SkipsUnparsableLogs(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, admin, "Mixed Logs Table")
+	a.NoError(err)
+
+	endHoldEmGame(t, tbl, admin.ID, admin.ID, map[int64]int{admin.ID: 150})
+
+	// A log whose shape the parser cannot read.
+	bad, err := testRepos.Games.CreateGame(cbg, tbl, "Texas Hold'em")
+	a.NoError(err)
+	a.NoError(testRepos.Games.EndGame(cbg, bad, map[string]interface{}{"seats": "not-an-array"}, map[int64]int{admin.ID: 10}))
+
+	out, err := s.getPlayerTendencies(cbg, nil, adminCaller(admin.ID), getPlayerTendenciesInput{ID: admin.ID})
+	require.NoError(t, err)
+
+	a.Equal(1, out.GamesAnalyzed)
+	a.Equal(1, out.GamesSkipped, "the unreadable log is reported, not hidden")
+	a.Equal(int64(2), out.GamesInRange)
+}
+
+func TestGetPlayerTendencies_SelfScoped(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	p1 := createPlayer(t)
+	p2 := createPlayer(t)
+
+	// The policy wrapper enforces scoping, so drive the registered handler.
+	wrapped := wrapHandler(accessSelfScoped, s.getPlayerTendencies)
+
+	_, _, err := wrapped(ctxForPlayer(p1.ID), nil, getPlayerTendenciesInput{ID: p2.ID})
+	a.Error(err)
+	a.Contains(err.Error(), "permission denied")
+
+	_, _, err = wrapped(ctxForPlayer(p1.ID), nil, getPlayerTendenciesInput{ID: p1.ID})
+	a.NoError(err)
+
+	// An admin may target anyone.
+	_, _, err = wrapped(ctxForAdmin(p1.ID), nil, getPlayerTendenciesInput{ID: p2.ID})
+	a.NoError(err)
+}
+
+func TestGetPlayerVariance(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+
+	night1, err := testRepos.Tables.CreateTable(cbg, admin, "Variance Night One")
+	a.NoError(err)
+	night2, err := testRepos.Tables.CreateTable(cbg, admin, "Variance Night Two")
+	a.NoError(err)
+
+	// Night one: +100, +50. Night two: -30.
+	endHoldEmGame(t, night1, admin.ID, admin.ID, map[int64]int{admin.ID: 100})
+	endHoldEmGame(t, night1, admin.ID, admin.ID, map[int64]int{admin.ID: 50})
+	endHoldEmGame(t, night2, admin.ID, admin.ID, map[int64]int{admin.ID: -30})
+
+	out, err := s.getPlayerVariance(cbg, nil, adminCaller(admin.ID), getPlayerVarianceInput{ID: admin.ID})
+	require.NoError(t, err)
+
+	a.Equal(admin.ID, out.Player.ID)
+
+	byGame := out.Variance.ByGame
+	a.Equal(3, byGame.Count)
+	a.Equal(120, byGame.TotalCents)
+	a.Equal("$1.20", byGame.TotalDisplay)
+	a.Equal(100, byGame.BestCents)
+	a.Equal(-30, byGame.WorstCents)
+	a.Greater(byGame.StdDevCents, 0.0)
+	a.NotEmpty(byGame.StdDevDisplay)
+
+	// A night aggregates its games, so two nights rather than three results.
+	bySession := out.Variance.BySession
+	a.Equal(2, bySession.Count)
+	a.Equal(150, bySession.BestCents)
+	a.Equal(-30, bySession.WorstCents)
+
+	require.NotNil(t, out.Variance.SessionStreaks.LongestWinning)
+	a.Equal(1, out.Variance.SessionStreaks.LongestWinning.Length)
+	a.Equal("winning", out.Variance.SessionStreaks.LongestWinning.Outcome)
+
+	require.NotNil(t, out.Variance.SessionStreaks.Current)
+	a.Equal("losing", out.Variance.SessionStreaks.Current.Outcome, "the most recent night lost")
+
+	require.NotNil(t, out.Variance.GameStreaks.LongestWinning)
+	a.Equal(2, out.Variance.GameStreaks.LongestWinning.Length)
+	a.Equal(150, out.Variance.GameStreaks.LongestWinning.NetCents)
+}
+
+// TestGetPlayerVariance_NoResults pins that a player with nothing to measure gets
+// zeroes and absent streaks rather than an error.
+func TestGetPlayerVariance_NoResults(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	p := createPlayer(t)
+
+	out, err := s.getPlayerVariance(cbg, nil, playerCaller(p.ID), getPlayerVarianceInput{ID: p.ID})
+	require.NoError(t, err)
+
+	a.Zero(out.Variance.ByGame.Count)
+	a.Zero(out.Variance.BySession.Count)
+	a.Nil(out.Variance.SessionStreaks.Current)
+	a.Nil(out.Variance.SessionStreaks.LongestWinning)
+	a.Nil(out.Variance.SessionStreaks.LongestLosing)
+}
+
+func TestGetPlayerVariance_SelfScoped(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	p1 := createPlayer(t)
+	p2 := createPlayer(t)
+
+	wrapped := wrapHandler(accessSelfScoped, s.getPlayerVariance)
+
+	_, _, err := wrapped(ctxForPlayer(p1.ID), nil, getPlayerVarianceInput{ID: p2.ID})
+	a.Error(err)
+	a.Contains(err.Error(), "permission denied")
+
+	_, _, err = wrapped(ctxForPlayer(p1.ID), nil, getPlayerVarianceInput{ID: p1.ID})
+	a.NoError(err)
+
+	_, _, err = wrapped(ctxForAdmin(p1.ID), nil, getPlayerVarianceInput{ID: p2.ID})
+	a.NoError(err)
+}
+
+// TestGetPlayerVariance_ExcludesDeletedTables pins that a soft-deleted table is
+// invisible here as it is across the rest of the read surface.
+func TestGetPlayerVariance_ExcludesDeletedTables(t *testing.T) {
+	a := assert.New(t)
+	s := newServer()
+
+	admin := createSiteAdmin(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, admin, "Deleted Variance Table")
+	a.NoError(err)
+
+	endHoldEmGame(t, tbl, admin.ID, admin.ID, map[int64]int{admin.ID: 500})
+
+	tbl.Deleted = true
+	a.NoError(testRepos.Tables.Save(cbg, tbl))
+
+	out, err := s.getPlayerVariance(cbg, nil, adminCaller(admin.ID), getPlayerVarianceInput{ID: admin.ID})
+	require.NoError(t, err)
+	a.Zero(out.Variance.ByGame.Count)
+
+	tend, err := s.getPlayerTendencies(cbg, nil, adminCaller(admin.ID), getPlayerTendenciesInput{ID: admin.ID})
+	require.NoError(t, err)
+	a.Zero(tend.Tendencies.HandsAnalyzed)
+}

--- a/pkg/deck/card.go
+++ b/pkg/deck/card.go
@@ -47,6 +47,21 @@ const (
 	LowAce  = 1
 )
 
+// Valid reports whether the suit is one of the defined suits.
+//
+// It exists for values that did not come from a live deck: a Card decoded from
+// persisted JSON carries whatever string was stored, and String panics on a suit
+// it cannot render. Callers handling untrusted cards ask this first rather than
+// keeping their own copy of the suit list.
+func (s Suit) Valid() bool {
+	switch s {
+	case Hearts, Clubs, Diamonds, Spades, Stars:
+		return true
+	}
+
+	return false
+}
+
 func (c *Card) String() string {
 	var rank string
 	switch c.Rank {

--- a/pkg/deck/card_test.go
+++ b/pkg/deck/card_test.go
@@ -203,3 +203,24 @@ func TestCard_UnsetAllBits(t *testing.T) {
 
 	assert.Equal(t, 0, c.BitField)
 }
+
+func TestSuit_Valid(t *testing.T) {
+	for _, suit := range []Suit{Hearts, Clubs, Diamonds, Spades, Stars} {
+		assert.True(t, suit.Valid(), "%s should be valid", suit)
+	}
+
+	// A suit decoded from persisted JSON can be anything; Valid is what lets a
+	// caller ask before String panics on it.
+	for _, suit := range []Suit{"", "swords", "HEARTS"} {
+		assert.False(t, suit.Valid(), "%q should not be valid", suit)
+	}
+}
+
+// TestSuit_Valid_MatchesString pins the two in step: every suit Valid accepts must
+// be one String can render, which is the whole point of the predicate.
+func TestSuit_Valid_MatchesString(t *testing.T) {
+	for _, suit := range []Suit{Hearts, Clubs, Diamonds, Spades, Stars} {
+		card := &Card{Rank: 5, Suit: suit}
+		assert.NotPanics(t, func() { _ = card.String() }, "%s", suit)
+	}
+}

--- a/pkg/model/analytics.go
+++ b/pkg/model/analytics.go
@@ -21,7 +21,14 @@ type GameLogRecord struct {
 }
 
 // GetPlayerGameLogs returns the persisted logs of completed games the player took
-// part in, newest first, capped at limit rows.
+// part in, newest first, capped at limit rows. The second return value is how many
+// games matched in total, ignoring the cap, so a caller can report that its
+// analysis covered only part of the range rather than silently truncating.
+//
+// The total comes from a window function rather than a second query: window
+// functions are evaluated before LIMIT, so one statement yields both the page and
+// the full count from a single consistent snapshot. A separate count query would
+// have to repeat this predicate verbatim, and the two would drift.
 //
 // Games with no log are excluded: a game row is created when the game starts and
 // only receives its data payload when it ends, so an in-progress or terminated
@@ -33,9 +40,9 @@ type GameLogRecord struct {
 // matching GetPlayerStats: a table is a single night by convention, so normalizing
 // every figure onto the table's date keeps the analytics tools reconcilable with
 // each other.
-func (r *PlayerRepo) GetPlayerGameLogs(ctx context.Context, playerID int64, from, to time.Time, limit int) ([]*GameLogRecord, error) {
+func (r *PlayerRepo) GetPlayerGameLogs(ctx context.Context, playerID int64, from, to time.Time, limit int) (records []*GameLogRecord, total int64, err error) {
 	const query = `
-SELECT g.id, t.uuid, t.name, g.game_type, g.created, g.data
+SELECT g.id, t.uuid, t.name, g.game_type, g.created, g.data, COUNT(*) OVER () AS total
 FROM games g
 INNER JOIN tables t ON g.table_uuid = t.uuid
 WHERE NOT t.deleted
@@ -53,49 +60,21 @@ LIMIT $4`
 
 	rows, err := r.db.QueryContext(ctx, query, playerID, from, to, limit)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer rows.Close()
 
-	records := make([]*GameLogRecord, 0)
+	records = make([]*GameLogRecord, 0)
 	for rows.Next() {
 		var rec GameLogRecord
-		if err := rows.Scan(&rec.GameID, &rec.TableUUID, &rec.TableName, &rec.GameType, &rec.Created, &rec.Data); err != nil {
-			return nil, err
+		if err := rows.Scan(&rec.GameID, &rec.TableUUID, &rec.TableName, &rec.GameType, &rec.Created, &rec.Data, &total); err != nil {
+			return nil, 0, err
 		}
 
 		records = append(records, &rec)
 	}
 
-	return records, rows.Err()
-}
-
-// GetPlayerGameLogsCount returns how many completed game logs match
-// GetPlayerGameLogs for the same arguments, ignoring its limit. It lets a caller
-// report that its analysis covered only part of the range rather than silently
-// truncating.
-func (r *PlayerRepo) GetPlayerGameLogsCount(ctx context.Context, playerID int64, from, to time.Time) (int64, error) {
-	const query = `
-SELECT COUNT(*)
-FROM games g
-INNER JOIN tables t ON g.table_uuid = t.uuid
-WHERE NOT t.deleted
-  AND g.data IS NOT NULL AND jsonb_typeof(g.data) <> 'null'
-  AND t.created >= $2 AND t.created <= $3
-  AND EXISTS (
-    SELECT 1
-    FROM players_tables_transactions ptt
-    INNER JOIN players_tables pt ON ptt.players_tables_id = pt.id
-    WHERE ptt.game_id = g.id
-      AND pt.player_id = $1
-  )`
-
-	var count int64
-	if err := r.db.QueryRowContext(ctx, query, playerID, from, to).Scan(&count); err != nil {
-		return 0, err
-	}
-
-	return count, nil
+	return records, total, rows.Err()
 }
 
 // PlayerGameResult is one game's net outcome for a player, in cents.
@@ -219,16 +198,8 @@ func NewSpread(values []int) Spread {
 		return s
 	}
 
-	s.BestCents = values[0]
-	s.WorstCents = values[0]
 	for _, v := range values {
 		s.TotalCents += v
-		if v > s.BestCents {
-			s.BestCents = v
-		}
-		if v < s.WorstCents {
-			s.WorstCents = v
-		}
 	}
 
 	s.MeanCents = float64(s.TotalCents) / float64(len(values))
@@ -246,6 +217,11 @@ func NewSpread(values []int) Spread {
 	sorted := make([]int, len(values))
 	copy(sorted, values)
 	sort.Ints(sorted)
+
+	// The median needs the values ordered anyway, so the extremes come from the
+	// ends of the sorted copy rather than from a second pass with two branches.
+	s.WorstCents = sorted[0]
+	s.BestCents = sorted[len(sorted)-1]
 
 	mid := len(sorted) / 2
 	if len(sorted)%2 == 0 {
@@ -372,24 +348,35 @@ func (r *PlayerRepo) GetPlayerVariance(ctx context.Context, playerID int64, from
 		return nil, err
 	}
 
-	gameValues := make([]int, 0, len(games))
-	gameStreakInput := make([]StreakInput, 0, len(games))
+	gameInput := make([]StreakInput, 0, len(games))
 	for _, g := range games {
-		gameValues = append(gameValues, g.NetCents)
-		gameStreakInput = append(gameStreakInput, StreakInput{NetCents: g.NetCents, At: g.Created})
+		gameInput = append(gameInput, StreakInput{NetCents: g.NetCents, At: g.Created})
 	}
 
-	sessionValues := make([]int, 0, len(sessions))
-	sessionStreakInput := make([]StreakInput, 0, len(sessions))
+	sessionInput := make([]StreakInput, 0, len(sessions))
 	for _, s := range sessions {
-		sessionValues = append(sessionValues, s.NetCents)
-		sessionStreakInput = append(sessionStreakInput, StreakInput{NetCents: s.NetCents, At: s.Created})
+		sessionInput = append(sessionInput, StreakInput{NetCents: s.NetCents, At: s.Created})
 	}
+
+	byGame, gameStreaks := spreadAndStreaks(gameInput)
+	bySession, sessionStreaks := spreadAndStreaks(sessionInput)
 
 	return &PlayerVariance{
-		ByGame:         NewSpread(gameValues),
-		BySession:      NewSpread(sessionValues),
-		GameStreaks:    ComputeStreaks(gameStreakInput),
-		SessionStreaks: ComputeStreaks(sessionStreakInput),
+		ByGame:         byGame,
+		BySession:      bySession,
+		GameStreaks:    gameStreaks,
+		SessionStreaks: sessionStreaks,
 	}, nil
+}
+
+// spreadAndStreaks derives both summaries from one chronological series. The
+// spread needs only the amounts, which StreakInput already carries, so this keeps
+// the two from being extracted separately and drifting apart.
+func spreadAndStreaks(results []StreakInput) (Spread, Streaks) {
+	values := make([]int, 0, len(results))
+	for _, res := range results {
+		values = append(values, res.NetCents)
+	}
+
+	return NewSpread(values), ComputeStreaks(results)
 }

--- a/pkg/model/analytics.go
+++ b/pkg/model/analytics.go
@@ -1,0 +1,395 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"sort"
+	"time"
+)
+
+// GameLogRecord is one completed game's persisted log plus the identity needed to
+// interpret it. GameType holds the games.game_type display name, which the caller
+// resolves to a parser.
+type GameLogRecord struct {
+	GameID    int64
+	TableUUID string
+	TableName string
+	GameType  string
+	Created   time.Time
+	Data      json.RawMessage
+}
+
+// GetPlayerGameLogs returns the persisted logs of completed games the player took
+// part in, newest first, capped at limit rows.
+//
+// Games with no log are excluded: a game row is created when the game starts and
+// only receives its data payload when it ends, so an in-progress or terminated
+// game has nothing to analyze. Participation is defined by the ledger — the player
+// has a transaction against the game — which is the same definition GetPlayerStats
+// uses for games played.
+//
+// The date range filters on tables.created rather than the game's own timestamp,
+// matching GetPlayerStats: a table is a single night by convention, so normalizing
+// every figure onto the table's date keeps the analytics tools reconcilable with
+// each other.
+func (r *PlayerRepo) GetPlayerGameLogs(ctx context.Context, playerID int64, from, to time.Time, limit int) ([]*GameLogRecord, error) {
+	const query = `
+SELECT g.id, t.uuid, t.name, g.game_type, g.created, g.data
+FROM games g
+INNER JOIN tables t ON g.table_uuid = t.uuid
+WHERE NOT t.deleted
+  AND g.data IS NOT NULL AND jsonb_typeof(g.data) <> 'null'
+  AND t.created >= $2 AND t.created <= $3
+  AND EXISTS (
+    SELECT 1
+    FROM players_tables_transactions ptt
+    INNER JOIN players_tables pt ON ptt.players_tables_id = pt.id
+    WHERE ptt.game_id = g.id
+      AND pt.player_id = $1
+  )
+ORDER BY g.created DESC, g.id DESC
+LIMIT $4`
+
+	rows, err := r.db.QueryContext(ctx, query, playerID, from, to, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	records := make([]*GameLogRecord, 0)
+	for rows.Next() {
+		var rec GameLogRecord
+		if err := rows.Scan(&rec.GameID, &rec.TableUUID, &rec.TableName, &rec.GameType, &rec.Created, &rec.Data); err != nil {
+			return nil, err
+		}
+
+		records = append(records, &rec)
+	}
+
+	return records, rows.Err()
+}
+
+// GetPlayerGameLogsCount returns how many completed game logs match
+// GetPlayerGameLogs for the same arguments, ignoring its limit. It lets a caller
+// report that its analysis covered only part of the range rather than silently
+// truncating.
+func (r *PlayerRepo) GetPlayerGameLogsCount(ctx context.Context, playerID int64, from, to time.Time) (int64, error) {
+	const query = `
+SELECT COUNT(*)
+FROM games g
+INNER JOIN tables t ON g.table_uuid = t.uuid
+WHERE NOT t.deleted
+  AND g.data IS NOT NULL AND jsonb_typeof(g.data) <> 'null'
+  AND t.created >= $2 AND t.created <= $3
+  AND EXISTS (
+    SELECT 1
+    FROM players_tables_transactions ptt
+    INNER JOIN players_tables pt ON ptt.players_tables_id = pt.id
+    WHERE ptt.game_id = g.id
+      AND pt.player_id = $1
+  )`
+
+	var count int64
+	if err := r.db.QueryRowContext(ctx, query, playerID, from, to).Scan(&count); err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// PlayerGameResult is one game's net outcome for a player, in cents.
+type PlayerGameResult struct {
+	GameID    int64
+	TableUUID string
+	GameType  string
+	Created   time.Time
+	NetCents  int
+}
+
+// PlayerSessionResult is one night's net outcome for a player, in cents. A session
+// is a table: the site's convention is one table per night.
+type PlayerSessionResult struct {
+	TableUUID   string
+	TableName   string
+	Created     time.Time
+	NetCents    int
+	GamesPlayed int
+}
+
+// GetPlayerGameResults returns the player's per-game net results, oldest first.
+//
+// Ordering is chronological because these results feed streak detection, which is
+// meaningless out of order. Only game-driven ledger entries count; manual balance
+// adjustments have no game_id and are excluded, so a buy-in correction cannot look
+// like a winning game.
+func (r *PlayerRepo) GetPlayerGameResults(ctx context.Context, playerID int64, from, to time.Time) ([]*PlayerGameResult, error) {
+	const query = `
+SELECT g.id, t.uuid, g.game_type, g.created, SUM(ptt.adjustment)
+FROM players_tables_transactions ptt
+INNER JOIN players_tables pt ON ptt.players_tables_id = pt.id
+INNER JOIN games g ON ptt.game_id = g.id
+INNER JOIN tables t ON pt.table_uuid = t.uuid
+WHERE pt.player_id = $1
+  AND NOT t.deleted
+  AND t.created >= $2 AND t.created <= $3
+GROUP BY g.id, t.uuid, g.game_type, g.created
+ORDER BY g.created ASC, g.id ASC`
+
+	rows, err := r.db.QueryContext(ctx, query, playerID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := make([]*PlayerGameResult, 0)
+	for rows.Next() {
+		var res PlayerGameResult
+		if err := rows.Scan(&res.GameID, &res.TableUUID, &res.GameType, &res.Created, &res.NetCents); err != nil {
+			return nil, err
+		}
+
+		results = append(results, &res)
+	}
+
+	return results, rows.Err()
+}
+
+// GetPlayerSessionResults returns the player's per-night net results, oldest first.
+//
+// Tables the player joined but never played a game at are excluded. Including them
+// would inject break-even nights that never happened, and since a break-even
+// result breaks a streak, a night spent watching would end a winning run.
+func (r *PlayerRepo) GetPlayerSessionResults(ctx context.Context, playerID int64, from, to time.Time) ([]*PlayerSessionResult, error) {
+	const query = `
+SELECT t.uuid,
+       t.name,
+       t.created,
+       COALESCE(SUM(ptt.adjustment) FILTER (WHERE ptt.game_id IS NOT NULL), 0) AS net,
+       COUNT(DISTINCT ptt.game_id) FILTER (WHERE ptt.game_id IS NOT NULL) AS games_played
+FROM players_tables pt
+INNER JOIN tables t ON pt.table_uuid = t.uuid
+LEFT JOIN players_tables_transactions ptt ON ptt.players_tables_id = pt.id
+WHERE pt.player_id = $1
+  AND NOT t.deleted
+  AND t.created >= $2 AND t.created <= $3
+GROUP BY t.uuid, t.name, t.created
+HAVING COUNT(DISTINCT ptt.game_id) FILTER (WHERE ptt.game_id IS NOT NULL) > 0
+ORDER BY t.created ASC, t.uuid ASC`
+
+	rows, err := r.db.QueryContext(ctx, query, playerID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := make([]*PlayerSessionResult, 0)
+	for rows.Next() {
+		var res PlayerSessionResult
+		if err := rows.Scan(&res.TableUUID, &res.TableName, &res.Created, &res.NetCents, &res.GamesPlayed); err != nil {
+			return nil, err
+		}
+
+		results = append(results, &res)
+	}
+
+	return results, rows.Err()
+}
+
+// Spread describes the distribution of a series of results, in cents.
+//
+// It exists because a total tells you nothing about how it was earned: two players
+// up $50 look identical until you see that one ground it out and the other swung
+// $400 in both directions. StdDevCents is the sample standard deviation and is
+// zero for fewer than two results, where it is undefined rather than small.
+type Spread struct {
+	Count       int
+	TotalCents  int
+	MeanCents   float64
+	StdDevCents float64
+	MedianCents float64
+	BestCents   int
+	WorstCents  int
+}
+
+// NewSpread computes the distribution of the given results.
+func NewSpread(values []int) Spread {
+	s := Spread{Count: len(values)}
+	if len(values) == 0 {
+		return s
+	}
+
+	s.BestCents = values[0]
+	s.WorstCents = values[0]
+	for _, v := range values {
+		s.TotalCents += v
+		if v > s.BestCents {
+			s.BestCents = v
+		}
+		if v < s.WorstCents {
+			s.WorstCents = v
+		}
+	}
+
+	s.MeanCents = float64(s.TotalCents) / float64(len(values))
+
+	if len(values) > 1 {
+		var sumSquares float64
+		for _, v := range values {
+			d := float64(v) - s.MeanCents
+			sumSquares += d * d
+		}
+
+		s.StdDevCents = math.Sqrt(sumSquares / float64(len(values)-1))
+	}
+
+	sorted := make([]int, len(values))
+	copy(sorted, values)
+	sort.Ints(sorted)
+
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 0 {
+		s.MedianCents = float64(sorted[mid-1]+sorted[mid]) / 2
+	} else {
+		s.MedianCents = float64(sorted[mid])
+	}
+
+	return s
+}
+
+// StreakOutcome describes what a run of results has in common.
+type StreakOutcome string
+
+// Streak outcomes.
+const (
+	StreakNone    StreakOutcome = ""
+	StreakWinning StreakOutcome = "winning"
+	StreakLosing  StreakOutcome = "losing"
+)
+
+// Streak is an unbroken run of results with the same outcome.
+//
+// A break-even result belongs to neither run and ends whatever streak was in
+// progress: a night where nothing changed is not a continued win.
+type Streak struct {
+	Outcome   StreakOutcome
+	Length    int
+	NetCents  int
+	StartedAt time.Time
+	EndedAt   time.Time
+}
+
+// Streaks summarizes the runs within a chronological series of results.
+type Streaks struct {
+	LongestWinning Streak
+	LongestLosing  Streak
+	// Current is the run still in progress as of the most recent result. It is the
+	// zero Streak when the latest result broke even.
+	Current Streak
+}
+
+// StreakInput is one dated result feeding streak detection.
+type StreakInput struct {
+	NetCents int
+	At       time.Time
+}
+
+// ComputeStreaks finds the longest winning and losing runs in a chronological
+// series, plus the run still in progress.
+//
+// Results must be ordered oldest first; the repository queries that feed this
+// order that way for exactly this reason. Ties are resolved in favor of the
+// earlier run, so a later streak has to actually be longer to displace it.
+func ComputeStreaks(results []StreakInput) Streaks {
+	var streaks Streaks
+	var current Streak
+
+	flush := func() {
+		switch current.Outcome {
+		case StreakWinning:
+			if current.Length > streaks.LongestWinning.Length {
+				streaks.LongestWinning = current
+			}
+		case StreakLosing:
+			if current.Length > streaks.LongestLosing.Length {
+				streaks.LongestLosing = current
+			}
+		}
+	}
+
+	for _, res := range results {
+		outcome := StreakNone
+		switch {
+		case res.NetCents > 0:
+			outcome = StreakWinning
+		case res.NetCents < 0:
+			outcome = StreakLosing
+		}
+
+		if outcome != current.Outcome {
+			flush()
+			current = Streak{Outcome: outcome, StartedAt: res.At}
+		}
+
+		current.Length++
+		current.NetCents += res.NetCents
+		current.EndedAt = res.At
+	}
+
+	flush()
+
+	if current.Outcome != StreakNone {
+		streaks.Current = current
+	}
+
+	return streaks
+}
+
+// PlayerVariance is a player's consistency profile: how their results are spread
+// out and how they ran in streaks, at both game and night granularity.
+type PlayerVariance struct {
+	ByGame    Spread
+	BySession Spread
+
+	GameStreaks    Streaks
+	SessionStreaks Streaks
+}
+
+// GetPlayerVariance computes a player's spread and streaks over the given range.
+//
+// Both granularities are reported because they answer different questions. The
+// per-game spread is the honest measure of swings, since it has enough data points
+// to mean something. The per-night streaks are what a player actually feels and
+// talks about, a night being the unit the game is organized around.
+func (r *PlayerRepo) GetPlayerVariance(ctx context.Context, playerID int64, from, to time.Time) (*PlayerVariance, error) {
+	games, err := r.GetPlayerGameResults(ctx, playerID, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	sessions, err := r.GetPlayerSessionResults(ctx, playerID, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	gameValues := make([]int, 0, len(games))
+	gameStreakInput := make([]StreakInput, 0, len(games))
+	for _, g := range games {
+		gameValues = append(gameValues, g.NetCents)
+		gameStreakInput = append(gameStreakInput, StreakInput{NetCents: g.NetCents, At: g.Created})
+	}
+
+	sessionValues := make([]int, 0, len(sessions))
+	sessionStreakInput := make([]StreakInput, 0, len(sessions))
+	for _, s := range sessions {
+		sessionValues = append(sessionValues, s.NetCents)
+		sessionStreakInput = append(sessionStreakInput, StreakInput{NetCents: s.NetCents, At: s.Created})
+	}
+
+	return &PlayerVariance{
+		ByGame:         NewSpread(gameValues),
+		BySession:      NewSpread(sessionValues),
+		GameStreaks:    ComputeStreaks(gameStreakInput),
+		SessionStreaks: ComputeStreaks(sessionStreakInput),
+	}, nil
+}

--- a/pkg/model/analytics_test.go
+++ b/pkg/model/analytics_test.go
@@ -1,0 +1,385 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// allTime is the widest range the date-filtered analytics queries accept, used by
+// tests that are not exercising the filter itself.
+func allTime() (from, to time.Time) {
+	return time.Unix(0, 0), time.Now().Add(time.Hour)
+}
+
+// analyticsPlayer returns a site admin, which exempts the player from the
+// create-another-table cool-down. These tests need several tables per player to
+// have more than one night to analyze.
+func analyticsPlayer(t *testing.T) *Player {
+	t.Helper()
+
+	p := player()
+	p.IsSiteAdmin = true
+	require.NoError(t, testRepos.Players.Save(cbg, p))
+
+	return p
+}
+
+// endGame creates a game at the table and immediately ends it with the given
+// per-player adjustments, which is the only path that writes game-driven ledger
+// rows. The stored game_type is a real display name so it resolves to a parser.
+func endGame(t *testing.T, tbl *Table, adjustments map[int64]int) *Game {
+	t.Helper()
+
+	g, err := testRepos.Games.CreateGame(cbg, tbl, "Bourré")
+	require.NoError(t, err)
+	require.NoError(t, testRepos.Games.EndGame(cbg, g, map[string]any{"ante": 50}, adjustments))
+
+	return g
+}
+
+// adjustBalanceWithoutGame writes a ledger row with no game_id, the shape a manual
+// balance correction takes. There is no repository method for it, so the test goes
+// through the same stored procedure the game path uses.
+func adjustBalanceWithoutGame(t *testing.T, pt *PlayerTable, amount int, reason string) {
+	t.Helper()
+
+	_, err := testDB.ExecContext(cbg, "SELECT adjust_balance($1, $2, $3, NULL, $4)", pt.ID, pt.Balance, amount, reason)
+	require.NoError(t, err)
+}
+
+func TestNewSpread(t *testing.T) {
+	// A ground-out result set and a swingy one with the same total: the whole point
+	// of reporting a spread is that these are not the same player.
+	steady := NewSpread([]int{10, 10, 10, 10})
+	swingy := NewSpread([]int{500, -400, 300, -360})
+
+	assert.Equal(t, 40, steady.TotalCents)
+	assert.Equal(t, 40, swingy.TotalCents)
+	assert.Equal(t, 10.0, steady.MeanCents)
+	assert.Equal(t, 10.0, swingy.MeanCents)
+	assert.Zero(t, steady.StdDevCents)
+	assert.Greater(t, swingy.StdDevCents, 400.0)
+}
+
+func TestNewSpread_Values(t *testing.T) {
+	got := NewSpread([]int{100, -50, 25})
+
+	assert.Equal(t, 3, got.Count)
+	assert.Equal(t, 75, got.TotalCents)
+	assert.InDelta(t, 25.0, got.MeanCents, 0.001)
+	assert.Equal(t, 25.0, got.MedianCents)
+	assert.Equal(t, 100, got.BestCents)
+	assert.Equal(t, -50, got.WorstCents)
+	assert.InDelta(t, 75.0, got.StdDevCents, 0.001)
+}
+
+func TestNewSpread_EvenCountMedian(t *testing.T) {
+	got := NewSpread([]int{10, 20, 30, 40})
+	assert.Equal(t, 25.0, got.MedianCents)
+}
+
+func TestNewSpread_Empty(t *testing.T) {
+	got := NewSpread(nil)
+
+	assert.Zero(t, got.Count)
+	assert.Zero(t, got.TotalCents)
+	assert.Zero(t, got.MeanCents)
+	assert.Zero(t, got.StdDevCents)
+	assert.Zero(t, got.BestCents)
+	assert.Zero(t, got.WorstCents)
+}
+
+// TestNewSpread_Single pins that a lone result reports no deviation rather than a
+// misleadingly small one: with one sample the standard deviation is undefined.
+func TestNewSpread_Single(t *testing.T) {
+	got := NewSpread([]int{250})
+
+	assert.Equal(t, 1, got.Count)
+	assert.Equal(t, 250.0, got.MeanCents)
+	assert.Equal(t, 250.0, got.MedianCents)
+	assert.Zero(t, got.StdDevCents)
+	assert.Equal(t, 250, got.BestCents)
+	assert.Equal(t, 250, got.WorstCents)
+}
+
+// streakInputs builds a chronological series one day apart, so ordering is
+// unambiguous and the recorded timestamps are checkable.
+func streakInputs(nets ...int) []StreakInput {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	inputs := make([]StreakInput, len(nets))
+	for i, net := range nets {
+		inputs[i] = StreakInput{NetCents: net, At: base.AddDate(0, 0, i)}
+	}
+
+	return inputs
+}
+
+func TestComputeStreaks(t *testing.T) {
+	// Two wins, then three losses, then one win still running.
+	got := ComputeStreaks(streakInputs(100, 50, -20, -30, -40, 75))
+
+	assert.Equal(t, StreakWinning, got.LongestWinning.Outcome)
+	assert.Equal(t, 2, got.LongestWinning.Length)
+	assert.Equal(t, 150, got.LongestWinning.NetCents)
+
+	assert.Equal(t, StreakLosing, got.LongestLosing.Outcome)
+	assert.Equal(t, 3, got.LongestLosing.Length)
+	assert.Equal(t, -90, got.LongestLosing.NetCents)
+
+	assert.Equal(t, StreakWinning, got.Current.Outcome)
+	assert.Equal(t, 1, got.Current.Length)
+	assert.Equal(t, 75, got.Current.NetCents)
+}
+
+// TestComputeStreaks_BreakEvenBreaksRun pins the rule that a night where nothing
+// changed is not a continued win.
+func TestComputeStreaks_BreakEvenBreaksRun(t *testing.T) {
+	got := ComputeStreaks(streakInputs(100, 100, 0, 100))
+
+	assert.Equal(t, 2, got.LongestWinning.Length, "the zero result ended the run")
+
+	// The series ends on a win, so a run is in progress; had it ended on the zero,
+	// there would be no current streak at all.
+	assert.Equal(t, StreakWinning, got.Current.Outcome)
+	assert.Equal(t, 1, got.Current.Length)
+}
+
+func TestComputeStreaks_EndsOnBreakEven(t *testing.T) {
+	got := ComputeStreaks(streakInputs(100, 100, 0))
+
+	assert.Equal(t, 2, got.LongestWinning.Length)
+	assert.Equal(t, StreakNone, got.Current.Outcome, "breaking even leaves no streak running")
+	assert.Zero(t, got.Current.Length)
+}
+
+// TestComputeStreaks_TiePrefersEarlier pins tie-breaking: a later run has to be
+// strictly longer to displace an earlier one.
+func TestComputeStreaks_TiePrefersEarlier(t *testing.T) {
+	got := ComputeStreaks(streakInputs(100, 200, -10, 300, 400))
+
+	assert.Equal(t, 2, got.LongestWinning.Length)
+	assert.Equal(t, 300, got.LongestWinning.NetCents, "the first of the two equal runs wins the tie")
+}
+
+func TestComputeStreaks_Timestamps(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	got := ComputeStreaks(streakInputs(100, 50, -20))
+
+	assert.Equal(t, base, got.LongestWinning.StartedAt)
+	assert.Equal(t, base.AddDate(0, 0, 1), got.LongestWinning.EndedAt)
+	assert.Equal(t, base.AddDate(0, 0, 2), got.LongestLosing.StartedAt)
+}
+
+func TestComputeStreaks_Empty(t *testing.T) {
+	got := ComputeStreaks(nil)
+
+	assert.Equal(t, StreakNone, got.LongestWinning.Outcome)
+	assert.Equal(t, StreakNone, got.LongestLosing.Outcome)
+	assert.Equal(t, StreakNone, got.Current.Outcome)
+}
+
+func TestComputeStreaks_AllLosses(t *testing.T) {
+	got := ComputeStreaks(streakInputs(-10, -20, -30))
+
+	assert.Equal(t, 3, got.LongestLosing.Length)
+	assert.Equal(t, -60, got.LongestLosing.NetCents)
+	assert.Zero(t, got.LongestWinning.Length)
+	assert.Equal(t, StreakLosing, got.Current.Outcome)
+}
+
+func TestPlayerRepo_GetPlayerVariance(t *testing.T) {
+	p := analyticsPlayer(t)
+	tbl1, err := testRepos.Tables.CreateTable(cbg, p, "night one")
+	require.NoError(t, err)
+	tbl2, err := testRepos.Tables.CreateTable(cbg, p, "night two")
+	require.NoError(t, err)
+
+	// Night one: up 100, up 50. Night two: down 30.
+	endGame(t, tbl1, map[int64]int{p.ID: 100})
+	endGame(t, tbl1, map[int64]int{p.ID: 50})
+	endGame(t, tbl2, map[int64]int{p.ID: -30})
+
+	from, to := allTime()
+	got, err := testRepos.Players.GetPlayerVariance(cbg, p.ID, from, to)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, got.ByGame.Count)
+	assert.Equal(t, 120, got.ByGame.TotalCents)
+	assert.Equal(t, 100, got.ByGame.BestCents)
+	assert.Equal(t, -30, got.ByGame.WorstCents)
+
+	// Two nights, not three games: the session view aggregates each table.
+	assert.Equal(t, 2, got.BySession.Count)
+	assert.Equal(t, 120, got.BySession.TotalCents)
+	assert.Equal(t, 150, got.BySession.BestCents)
+	assert.Equal(t, -30, got.BySession.WorstCents)
+
+	assert.Equal(t, 2, got.GameStreaks.LongestWinning.Length)
+	assert.Equal(t, 1, got.SessionStreaks.LongestWinning.Length)
+	assert.Equal(t, 1, got.SessionStreaks.LongestLosing.Length)
+}
+
+// TestPlayerRepo_GetPlayerVariance_ExcludesNonGameLedger pins that manual balance
+// adjustments do not look like winning games.
+func TestPlayerRepo_GetPlayerVariance_ExcludesNonGameLedger(t *testing.T) {
+	p := analyticsPlayer(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, p, "adjustments")
+	require.NoError(t, err)
+
+	players, err := testRepos.Tables.GetPlayers(cbg, tbl)
+	require.NoError(t, err)
+	require.Len(t, players, 1, "creating a table seats its creator")
+	adjustBalanceWithoutGame(t, players[0], 5000, "buy-in")
+
+	endGame(t, tbl, map[int64]int{p.ID: -100})
+
+	from, to := allTime()
+	got, err := testRepos.Players.GetPlayerVariance(cbg, p.ID, from, to)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, got.ByGame.Count, "the buy-in is not a game")
+	assert.Equal(t, -100, got.ByGame.TotalCents)
+	assert.Equal(t, -100, got.BySession.TotalCents)
+}
+
+// TestPlayerRepo_GetPlayerVariance_SkipsTablesWithNoGames pins that a night spent
+// watching does not appear as a break-even session and end a winning run.
+func TestPlayerRepo_GetPlayerVariance_SkipsTablesWithNoGames(t *testing.T) {
+	p := analyticsPlayer(t)
+	played, err := testRepos.Tables.CreateTable(cbg, p, "played")
+	require.NoError(t, err)
+	// Creating a table seats its creator, so this is a night joined but never
+	// played at.
+	_, err = testRepos.Tables.CreateTable(cbg, p, "watched")
+	require.NoError(t, err)
+
+	endGame(t, played, map[int64]int{p.ID: 100})
+
+	from, to := allTime()
+	got, err := testRepos.Players.GetPlayerVariance(cbg, p.ID, from, to)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, got.BySession.Count)
+	assert.Equal(t, StreakWinning, got.SessionStreaks.Current.Outcome)
+}
+
+func TestPlayerRepo_GetPlayerVariance_NoResults(t *testing.T) {
+	p := analyticsPlayer(t)
+
+	from, to := allTime()
+	got, err := testRepos.Players.GetPlayerVariance(cbg, p.ID, from, to)
+	require.NoError(t, err)
+
+	assert.Zero(t, got.ByGame.Count)
+	assert.Zero(t, got.BySession.Count)
+	assert.Equal(t, StreakNone, got.SessionStreaks.Current.Outcome)
+}
+
+func TestPlayerRepo_GetPlayerGameLogs(t *testing.T) {
+	p := analyticsPlayer(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, p, "logged")
+	require.NoError(t, err)
+
+	// A finished game with a log, and one that never finished.
+	withLog, err := testRepos.Games.CreateGame(cbg, tbl, "Bourré")
+	require.NoError(t, err)
+	require.NoError(t, testRepos.Games.EndGame(cbg, withLog, map[string]any{"ante": 50}, map[int64]int{p.ID: 100}))
+
+	_, err = testRepos.Games.CreateGame(cbg, tbl, "Bourré")
+	require.NoError(t, err)
+
+	from, to := allTime()
+	logs, err := testRepos.Players.GetPlayerGameLogs(cbg, p.ID, from, to, 100)
+	require.NoError(t, err)
+
+	require.Len(t, logs, 1, "an unfinished game has no log to analyze")
+	assert.Equal(t, withLog.ID, logs[0].GameID)
+	assert.Equal(t, tbl.UUID, logs[0].TableUUID)
+	assert.Equal(t, "Bourré", logs[0].GameType)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Data, &payload))
+	assert.Equal(t, float64(50), payload["ante"])
+
+	count, err := testRepos.Players.GetPlayerGameLogsCount(cbg, p.ID, from, to)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}
+
+// TestPlayerRepo_GetPlayerGameLogs_Limit pins that the count reports the full
+// match set even when the returned rows are capped, so a caller can say its
+// analysis was partial rather than silently truncating.
+func TestPlayerRepo_GetPlayerGameLogs_Limit(t *testing.T) {
+	p := analyticsPlayer(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, p, "many games")
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		g, err := testRepos.Games.CreateGame(cbg, tbl, "Bourré")
+		require.NoError(t, err)
+		require.NoError(t, testRepos.Games.EndGame(cbg, g, map[string]any{"ante": 50}, map[int64]int{p.ID: 10}))
+	}
+
+	from, to := allTime()
+	logs, err := testRepos.Players.GetPlayerGameLogs(cbg, p.ID, from, to, 2)
+	require.NoError(t, err)
+	assert.Len(t, logs, 2)
+
+	count, err := testRepos.Players.GetPlayerGameLogsCount(cbg, p.ID, from, to)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+}
+
+// TestPlayerRepo_GetPlayerGameLogs_ExcludesOtherPlayers pins that participation is
+// defined by the ledger: a game at a table the player is at, but did not play in,
+// is not theirs.
+func TestPlayerRepo_GetPlayerGameLogs_ExcludesOtherPlayers(t *testing.T) {
+	p1 := analyticsPlayer(t)
+	p2 := analyticsPlayer(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, p1, "shared")
+	require.NoError(t, err)
+
+	_, err = testRepos.Tables.Join(cbg, p2, tbl)
+	require.NoError(t, err)
+
+	g, err := testRepos.Games.CreateGame(cbg, tbl, "Bourré")
+	require.NoError(t, err)
+	require.NoError(t, testRepos.Games.EndGame(cbg, g, map[string]any{"ante": 50}, map[int64]int{p1.ID: 100}))
+
+	from, to := allTime()
+
+	logs, err := testRepos.Players.GetPlayerGameLogs(cbg, p1.ID, from, to, 100)
+	require.NoError(t, err)
+	assert.Len(t, logs, 1)
+
+	logs, err = testRepos.Players.GetPlayerGameLogs(cbg, p2.ID, from, to, 100)
+	require.NoError(t, err)
+	assert.Empty(t, logs, "sitting at the table is not playing the game")
+}
+
+func TestPlayerRepo_GetPlayerGameLogs_ExcludesDeletedTables(t *testing.T) {
+	p := analyticsPlayer(t)
+	tbl, err := testRepos.Tables.CreateTable(cbg, p, "doomed")
+	require.NoError(t, err)
+
+	g, err := testRepos.Games.CreateGame(cbg, tbl, "Bourré")
+	require.NoError(t, err)
+	require.NoError(t, testRepos.Games.EndGame(cbg, g, map[string]any{"ante": 50}, map[int64]int{p.ID: 100}))
+
+	tbl.Deleted = true
+	require.NoError(t, testRepos.Tables.Save(cbg, tbl))
+
+	from, to := allTime()
+
+	logs, err := testRepos.Players.GetPlayerGameLogs(cbg, p.ID, from, to, 100)
+	require.NoError(t, err)
+	assert.Empty(t, logs)
+
+	got, err := testRepos.Players.GetPlayerVariance(cbg, p.ID, from, to)
+	require.NoError(t, err)
+	assert.Zero(t, got.ByGame.Count, "a deleted table is invisible to every read")
+}

--- a/pkg/model/analytics_test.go
+++ b/pkg/model/analytics_test.go
@@ -65,45 +65,51 @@ func TestNewSpread(t *testing.T) {
 	assert.Greater(t, swingy.StdDevCents, 400.0)
 }
 
+// TestNewSpread_Values covers the field math across the shapes that behave
+// differently: an odd count, an even count (median averages the middle pair), a
+// lone result (deviation undefined, reported as zero rather than misleadingly
+// small), and nothing at all.
 func TestNewSpread_Values(t *testing.T) {
-	got := NewSpread([]int{100, -50, 25})
+	testCases := []struct {
+		name string
+		in   []int
+		want Spread
+	}{
+		{
+			name: "odd count",
+			in:   []int{100, -50, 25},
+			want: Spread{Count: 3, TotalCents: 75, MeanCents: 25, MedianCents: 25, StdDevCents: 75, BestCents: 100, WorstCents: -50},
+		},
+		{
+			name: "even count averages the middle pair",
+			in:   []int{10, 20, 30, 40},
+			want: Spread{Count: 4, TotalCents: 100, MeanCents: 25, MedianCents: 25, StdDevCents: 12.909944487358056, BestCents: 40, WorstCents: 10},
+		},
+		{
+			name: "single result has no deviation",
+			in:   []int{250},
+			want: Spread{Count: 1, TotalCents: 250, MeanCents: 250, MedianCents: 250, BestCents: 250, WorstCents: 250},
+		},
+		{
+			name: "empty",
+			in:   nil,
+			want: Spread{},
+		},
+	}
 
-	assert.Equal(t, 3, got.Count)
-	assert.Equal(t, 75, got.TotalCents)
-	assert.InDelta(t, 25.0, got.MeanCents, 0.001)
-	assert.Equal(t, 25.0, got.MedianCents)
-	assert.Equal(t, 100, got.BestCents)
-	assert.Equal(t, -50, got.WorstCents)
-	assert.InDelta(t, 75.0, got.StdDevCents, 0.001)
-}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewSpread(tc.in)
 
-func TestNewSpread_EvenCountMedian(t *testing.T) {
-	got := NewSpread([]int{10, 20, 30, 40})
-	assert.Equal(t, 25.0, got.MedianCents)
-}
-
-func TestNewSpread_Empty(t *testing.T) {
-	got := NewSpread(nil)
-
-	assert.Zero(t, got.Count)
-	assert.Zero(t, got.TotalCents)
-	assert.Zero(t, got.MeanCents)
-	assert.Zero(t, got.StdDevCents)
-	assert.Zero(t, got.BestCents)
-	assert.Zero(t, got.WorstCents)
-}
-
-// TestNewSpread_Single pins that a lone result reports no deviation rather than a
-// misleadingly small one: with one sample the standard deviation is undefined.
-func TestNewSpread_Single(t *testing.T) {
-	got := NewSpread([]int{250})
-
-	assert.Equal(t, 1, got.Count)
-	assert.Equal(t, 250.0, got.MeanCents)
-	assert.Equal(t, 250.0, got.MedianCents)
-	assert.Zero(t, got.StdDevCents)
-	assert.Equal(t, 250, got.BestCents)
-	assert.Equal(t, 250, got.WorstCents)
+			assert.Equal(t, tc.want.Count, got.Count)
+			assert.Equal(t, tc.want.TotalCents, got.TotalCents)
+			assert.Equal(t, tc.want.BestCents, got.BestCents)
+			assert.Equal(t, tc.want.WorstCents, got.WorstCents)
+			assert.InDelta(t, tc.want.MeanCents, got.MeanCents, 0.001)
+			assert.InDelta(t, tc.want.MedianCents, got.MedianCents, 0.001)
+			assert.InDelta(t, tc.want.StdDevCents, got.StdDevCents, 0.001)
+		})
+	}
 }
 
 // streakInputs builds a chronological series one day apart, so ordering is
@@ -293,10 +299,11 @@ func TestPlayerRepo_GetPlayerGameLogs(t *testing.T) {
 	require.NoError(t, err)
 
 	from, to := allTime()
-	logs, err := testRepos.Players.GetPlayerGameLogs(cbg, p.ID, from, to, 100)
+	logs, total, err := testRepos.Players.GetPlayerGameLogs(cbg, p.ID, from, to, 100)
 	require.NoError(t, err)
 
 	require.Len(t, logs, 1, "an unfinished game has no log to analyze")
+	assert.Equal(t, int64(1), total)
 	assert.Equal(t, withLog.ID, logs[0].GameID)
 	assert.Equal(t, tbl.UUID, logs[0].TableUUID)
 	assert.Equal(t, "Bourré", logs[0].GameType)
@@ -304,10 +311,6 @@ func TestPlayerRepo_GetPlayerGameLogs(t *testing.T) {
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(logs[0].Data, &payload))
 	assert.Equal(t, float64(50), payload["ante"])
-
-	count, err := testRepos.Players.GetPlayerGameLogsCount(cbg, p.ID, from, to)
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), count)
 }
 
 // TestPlayerRepo_GetPlayerGameLogs_Limit pins that the count reports the full
@@ -325,13 +328,12 @@ func TestPlayerRepo_GetPlayerGameLogs_Limit(t *testing.T) {
 	}
 
 	from, to := allTime()
-	logs, err := testRepos.Players.GetPlayerGameLogs(cbg, p.ID, from, to, 2)
+	// The window-function total reports the full match set even though the page is
+	// capped, which is what lets a caller say its analysis was partial.
+	logs, total, err := testRepos.Players.GetPlayerGameLogs(cbg, p.ID, from, to, 2)
 	require.NoError(t, err)
 	assert.Len(t, logs, 2)
-
-	count, err := testRepos.Players.GetPlayerGameLogsCount(cbg, p.ID, from, to)
-	require.NoError(t, err)
-	assert.Equal(t, int64(3), count)
+	assert.Equal(t, int64(3), total)
 }
 
 // TestPlayerRepo_GetPlayerGameLogs_ExcludesOtherPlayers pins that participation is
@@ -352,13 +354,14 @@ func TestPlayerRepo_GetPlayerGameLogs_ExcludesOtherPlayers(t *testing.T) {
 
 	from, to := allTime()
 
-	logs, err := testRepos.Players.GetPlayerGameLogs(cbg, p1.ID, from, to, 100)
+	logs, _, err := testRepos.Players.GetPlayerGameLogs(cbg, p1.ID, from, to, 100)
 	require.NoError(t, err)
 	assert.Len(t, logs, 1)
 
-	logs, err = testRepos.Players.GetPlayerGameLogs(cbg, p2.ID, from, to, 100)
+	logs, total, err := testRepos.Players.GetPlayerGameLogs(cbg, p2.ID, from, to, 100)
 	require.NoError(t, err)
 	assert.Empty(t, logs, "sitting at the table is not playing the game")
+	assert.Zero(t, total, "no rows means no window-function total")
 }
 
 func TestPlayerRepo_GetPlayerGameLogs_ExcludesDeletedTables(t *testing.T) {
@@ -375,7 +378,7 @@ func TestPlayerRepo_GetPlayerGameLogs_ExcludesDeletedTables(t *testing.T) {
 
 	from, to := allTime()
 
-	logs, err := testRepos.Players.GetPlayerGameLogs(cbg, p.ID, from, to, 100)
+	logs, _, err := testRepos.Players.GetPlayerGameLogs(cbg, p.ID, from, to, 100)
 	require.NoError(t, err)
 	assert.Empty(t, logs)
 

--- a/pkg/model/game.go
+++ b/pkg/model/game.go
@@ -18,6 +18,7 @@ type Game struct {
 	TableUUID string
 	GameType  string
 	data      interface{}
+	rawData   json.RawMessage
 	Created   time.Time
 	Ended     time.Time
 }
@@ -29,10 +30,20 @@ const gamesColumns = `id, parent_id, table_uuid, game_type, data, created, ended
 // log is actually needed.
 const gamesColumnsNoData = `id, parent_id, table_uuid, game_type, created, ended`
 
-// Data returns the game's log/state payload (the jsonb `data` column). It is nil
-// on games loaded without the data column (e.g. ListGamesByTable).
+// Data returns the game's log/state payload (the jsonb `data` column) decoded into
+// a generic value. It is nil on games loaded without the data column (e.g.
+// ListGamesByTable).
 func (g *Game) Data() interface{} {
 	return g.data
+}
+
+// RawData returns the game's log/state payload as the bytes stored in the column,
+// for callers that decode it into a type of their own. Taking the bytes directly
+// avoids marshalling Data back to JSON just to decode it again, and it preserves
+// values the generic decode flattens (integers become float64 in an interface{}).
+// It is nil on games loaded without the data column.
+func (g *Game) RawData() json.RawMessage {
+	return g.rawData
 }
 
 func gameByRow(row db.Scanner) (*Game, error) {
@@ -47,6 +58,7 @@ func gameByRow(row db.Scanner) (*Game, error) {
 
 	g.ParentID = parentID.Int64
 	if data != nil {
+		g.rawData = data
 		if err := json.Unmarshal(data, &g.data); err != nil {
 			return nil, err
 		}

--- a/pkg/playable/aceydeucey/parse_log.go
+++ b/pkg/playable/aceydeucey/parse_log.go
@@ -61,17 +61,12 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 		Rounds: len(rounds),
 	}
 
-	wagered := make(map[int64]bool)
-	turns := make(map[int64]int)
-
 	for i, round := range rounds {
 		street := "turn-" + strconv.Itoa(i+1)
 		hand.PotCents = round.Pot
 
 		p := hand.Participant(round.PlayerID)
 		for _, game := range round.Games {
-			turns[round.PlayerID]++
-
 			if game.FirstCard != nil && game.MiddleCard != nil && len(p.StartingCards) == 0 {
 				p.StartingCards = []*deck.Card{game.FirstCard, game.MiddleCard}
 			}
@@ -85,7 +80,6 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 				continue
 			}
 
-			wagered[round.PlayerID] = true
 			hand.AddAction(&gamelog.Action{
 				Street:      street,
 				PlayerID:    round.PlayerID,
@@ -103,9 +97,11 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 		}
 	}
 
+	// Every turn records exactly one action, a bet or a pass, so the tallies already
+	// answer both questions and no parallel bookkeeping is needed.
 	for _, p := range hand.Participants {
-		p.VoluntarilyPlayed = wagered[p.PlayerID]
-		p.Folded = turns[p.PlayerID] > 0 && !wagered[p.PlayerID]
+		p.VoluntarilyPlayed = p.Counts[gamelog.KindBet] > 0
+		p.Folded = !p.VoluntarilyPlayed && p.Counts[gamelog.KindPass] > 0
 	}
 
 	return hand, nil

--- a/pkg/playable/aceydeucey/parse_log.go
+++ b/pkg/playable/aceydeucey/parse_log.go
@@ -1,0 +1,112 @@
+package aceydeucey
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+)
+
+// persistedRound mirrors the roundJSON written by Round.MarshalJSON.
+//
+// Unlike every other game, Acey Deucey persists a bare array of rounds rather than
+// a wrapper object, so the log carries no game-level ante or options — only the
+// rounds themselves.
+type persistedRound struct {
+	PlayerID int64             `json:"playerId"`
+	Games    []persistedSingle `json:"games"`
+	Pot      int               `json:"pot"`
+}
+
+type persistedSingle struct {
+	FirstCard  *deck.Card `json:"firstCard"`
+	MiddleCard *deck.Card `json:"middleCard"`
+	LastCard   *deck.Card `json:"lastCard"`
+	Bet        struct {
+		Amount int `json:"amount"`
+	} `json:"bet"`
+	Result string `json:"result"`
+}
+
+// Single-game results that matter to normalization.
+const (
+	resultWon  = "won"
+	resultPass = "pass"
+)
+
+// ParseGameLog decodes a persisted Acey Deucey log into a normalized hand.
+//
+// Acey Deucey is played in turns against the pot rather than against the other
+// players: on each turn one player sees two cards, chooses a wager, and a third
+// card decides it. That shapes the normalized fields:
+//
+//   - VoluntarilyPlayed is true when the player wagered anything. Passing is the
+//     free option, so declining to bet is the direct analogue of not entering a pot.
+//   - Folded is true only when the player passed on every turn they took, since a
+//     pass is the closest thing the game has to giving up a hand.
+//   - WentToShowdown counts turns that were actually resolved by the third card.
+//     There is no opponent to beat, so a resolved wager is the showdown.
+//
+// AnteCents is always zero: the ante lives in the game options, which this log
+// does not persist.
+func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	var rounds []persistedRound
+	if err := json.Unmarshal(raw, &rounds); err != nil {
+		return nil, fmt.Errorf("could not decode acey deucey log: %w", err)
+	}
+
+	hand := &gamelog.Hand{
+		Rounds: len(rounds),
+	}
+
+	wagered := make(map[int64]bool)
+	turns := make(map[int64]int)
+
+	for i, round := range rounds {
+		street := "turn-" + strconv.Itoa(i+1)
+		hand.PotCents = round.Pot
+
+		p := hand.Participant(round.PlayerID)
+		for _, game := range round.Games {
+			turns[round.PlayerID]++
+
+			if game.FirstCard != nil && game.MiddleCard != nil && len(p.StartingCards) == 0 {
+				p.StartingCards = []*deck.Card{game.FirstCard, game.MiddleCard}
+			}
+
+			if game.Result == resultPass || game.Bet.Amount == 0 {
+				hand.AddAction(&gamelog.Action{
+					Street:   street,
+					PlayerID: round.PlayerID,
+					Kind:     gamelog.KindPass,
+				})
+				continue
+			}
+
+			wagered[round.PlayerID] = true
+			hand.AddAction(&gamelog.Action{
+				Street:      street,
+				PlayerID:    round.PlayerID,
+				Kind:        gamelog.KindBet,
+				AmountCents: game.Bet.Amount,
+			})
+
+			p.WentToShowdown = true
+			if game.Result == resultWon {
+				p.Won = true
+			}
+			if game.LastCard != nil {
+				p.FinalCards = []*deck.Card{game.LastCard}
+			}
+		}
+	}
+
+	for _, p := range hand.Participants {
+		p.VoluntarilyPlayed = wagered[p.PlayerID]
+		p.Folded = turns[p.PlayerID] > 0 && !wagered[p.PlayerID]
+	}
+
+	return hand, nil
+}

--- a/pkg/playable/aceydeucey/parse_log_test.go
+++ b/pkg/playable/aceydeucey/parse_log_test.go
@@ -1,0 +1,109 @@
+package aceydeucey
+
+import (
+	"encoding/json"
+	"testing"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalRounds serializes the live rounds slice exactly as EndGame persists it.
+// Acey Deucey stores a bare array rather than a wrapper object, and Round has a
+// custom MarshalJSON, so this pins both.
+func marshalRounds(t *testing.T, rounds []*Round) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(rounds)
+	require.NoError(t, err)
+
+	return raw
+}
+
+// newTestRound builds a round with a real deck, which Round.MarshalJSON requires
+// in order to report the remaining card count.
+func newTestRound(playerID int64, pot int, games ...*SingleGame) *Round {
+	r := NewRound(DefaultOptions(), playerID, deck.New(), pot)
+	r.Games = games
+	r.Pot = pot
+
+	return r
+}
+
+func TestParseGameLog(t *testing.T) {
+	rounds := []*Round{
+		newTestRound(1, 200, &SingleGame{
+			FirstCard:  deck.CardFromString("5c"),
+			MiddleCard: deck.CardFromString("12d"),
+			LastCard:   deck.CardFromString("9h"),
+			Bet:        Bet{Amount: 100},
+			Adjustment: 100,
+			Result:     SingleGameResultWon,
+		}),
+		newTestRound(2, 100, &SingleGame{
+			FirstCard:  deck.CardFromString("3c"),
+			MiddleCard: deck.CardFromString("4d"),
+			Bet:        Bet{Amount: 0},
+			Result:     SingleGameResultPass,
+		}),
+	}
+
+	hand, err := ParseGameLog(marshalRounds(t, rounds))
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, hand.Rounds)
+	assert.Equal(t, 100, hand.PotCents, "pot reflects the final round")
+	assert.Zero(t, hand.AnteCents, "the ante lives in options, which this log omits")
+	assert.Len(t, hand.Actions, 2)
+
+	// Player 1 wagered and won.
+	p1 := hand.Participant(1)
+	assert.True(t, p1.VoluntarilyPlayed)
+	assert.False(t, p1.Folded)
+	assert.True(t, p1.WentToShowdown)
+	assert.True(t, p1.Won)
+	assert.Equal(t, 100, p1.AmountWageredCents)
+	assert.Equal(t, gamelog.KindBet, hand.Actions[0].Kind)
+	assert.Len(t, p1.StartingCards, 2, "the two outer cards are what the bet is made on")
+
+	// Player 2 passed on their only turn, which is the closest thing the game has
+	// to giving up a hand.
+	p2 := hand.Participant(2)
+	assert.False(t, p2.VoluntarilyPlayed)
+	assert.True(t, p2.Folded)
+	assert.False(t, p2.WentToShowdown)
+	assert.Equal(t, gamelog.KindPass, hand.Actions[1].Kind)
+	assert.Zero(t, p2.AmountWageredCents)
+}
+
+func TestParseGameLog_Loss(t *testing.T) {
+	rounds := []*Round{
+		newTestRound(1, 300, &SingleGame{
+			FirstCard:  deck.CardFromString("5c"),
+			MiddleCard: deck.CardFromString("12d"),
+			LastCard:   deck.CardFromString("14h"),
+			Bet:        Bet{Amount: 150},
+			Adjustment: -150,
+			Result:     SingleGameResultLost,
+		}),
+	}
+
+	hand, err := ParseGameLog(marshalRounds(t, rounds))
+	require.NoError(t, err)
+
+	p1 := hand.Participant(1)
+	assert.True(t, p1.VoluntarilyPlayed)
+	assert.True(t, p1.WentToShowdown, "a resolved wager is the showdown")
+	assert.False(t, p1.Won)
+	assert.Equal(t, 150, p1.AmountWageredCents)
+}
+
+func TestParseGameLog_Invalid(t *testing.T) {
+	hand, err := ParseGameLog(json.RawMessage(`{"not":"an-array"}`))
+	assert.Nil(t, hand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not decode acey deucey log")
+}

--- a/pkg/playable/bourre/parse_log.go
+++ b/pkg/playable/bourre/parse_log.go
@@ -1,0 +1,158 @@
+package bourre
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+)
+
+// persistedLog mirrors the JSON written by gameLog. Parent links to the previous
+// hand when a Bourré game continues across several hands, so a single persisted
+// log can carry a whole chain.
+type persistedLog struct {
+	Parent     *persistedLog      `json:"parent"`
+	Ante       int                `json:"ante"`
+	InitialPot int                `json:"initialPot"`
+	TrumpCard  *deck.Card         `json:"trumpCard"`
+	Seats      []persistedSeat    `json:"seats"`
+	Discards   []persistedDiscard `json:"discards"`
+	Tricks     []persistedTrick   `json:"tricks"`
+	Result     *persistedResult   `json:"result"`
+}
+
+type persistedSeat struct {
+	PlayerID     int64        `json:"playerId"`
+	StartingHand []*deck.Card `json:"startingHand"`
+}
+
+type persistedDiscard struct {
+	PlayerID  int64        `json:"playerId"`
+	Folded    bool         `json:"folded"`
+	Discarded []*deck.Card `json:"discarded"`
+}
+
+type persistedTrick struct {
+	Number   int             `json:"number"`
+	Plays    []persistedPlay `json:"plays"`
+	WinnerID int64           `json:"winnerId"`
+}
+
+type persistedPlay struct {
+	PlayerID int64      `json:"playerId"`
+	Card     *deck.Card `json:"card"`
+}
+
+// persistedResult mirrors bourre.Result. Its player slices hold the Player struct,
+// which has no JSON tags and exports only PlayerID, so it serializes with the Go
+// field name.
+type persistedResult struct {
+	Winners       []persistedPlayer `json:"Winners"`
+	Folded        []persistedPlayer `json:"Folded"`
+	WinningAmount int               `json:"WinningAmount"`
+	OldPot        int               `json:"OldPot"`
+}
+
+type persistedPlayer struct {
+	PlayerID int64 `json:"PlayerID"`
+}
+
+// ParseGameLog decodes a persisted Bourré log into a normalized hand.
+//
+// Bourré's fold is a decision made at the trade-in phase, before any trick is
+// played, so it maps to a drop-out rather than a poker fold: the player forfeits
+// their claim on the pot but nothing they have already wagered. Everyone who did
+// not fold plays out every trick, so a non-folding player always reaches the
+// showdown when at least one opponent also stayed in.
+//
+// Only the final hand of a continuation chain is normalized. Parent hands are
+// counted toward Rounds so the chain length is visible, but their tricks are not
+// merged in: each hand in the chain was its own deal with its own pot, and
+// flattening them would double-count every player's participation.
+func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	var log persistedLog
+	if err := json.Unmarshal(raw, &log); err != nil {
+		return nil, fmt.Errorf("could not decode bourre log: %w", err)
+	}
+
+	rounds := 1
+	for parent := log.Parent; parent != nil; parent = parent.Parent {
+		rounds++
+	}
+
+	hand := &gamelog.Hand{
+		AnteCents: log.Ante,
+		Rounds:    rounds,
+	}
+
+	if log.TrumpCard != nil {
+		hand.Board = []*deck.Card{log.TrumpCard}
+	}
+	if log.Result != nil {
+		hand.PotCents = log.Result.OldPot
+	}
+
+	for _, seat := range log.Seats {
+		hand.Participant(seat.PlayerID).StartingCards = seat.StartingHand
+	}
+
+	folded := make(map[int64]bool, len(log.Discards))
+	for _, d := range log.Discards {
+		if d.Folded {
+			folded[d.PlayerID] = true
+			hand.AddAction(&gamelog.Action{
+				Street:   "trade-in",
+				PlayerID: d.PlayerID,
+				Kind:     gamelog.KindDropOut,
+			})
+			continue
+		}
+
+		hand.AddAction(&gamelog.Action{
+			Street:   "trade-in",
+			PlayerID: d.PlayerID,
+			Kind:     gamelog.KindDiscard,
+			Cards:    d.Discarded,
+		})
+	}
+
+	for _, trick := range log.Tricks {
+		street := "trick-" + strconv.Itoa(trick.Number)
+		for _, play := range trick.Plays {
+			hand.AddAction(&gamelog.Action{
+				Street:   street,
+				PlayerID: play.PlayerID,
+				Kind:     gamelog.KindPlayCard,
+				Cards:    []*deck.Card{play.Card},
+			})
+		}
+	}
+
+	// Folding is the only way out of a Bourré hand, so everyone else contested it.
+	contested := 0
+	for _, p := range hand.Participants {
+		if !folded[p.PlayerID] {
+			contested++
+		}
+	}
+
+	for _, p := range hand.Participants {
+		if folded[p.PlayerID] {
+			p.Folded = true
+			continue
+		}
+
+		p.VoluntarilyPlayed = true
+		p.WentToShowdown = contested > 1
+	}
+
+	if log.Result != nil {
+		for _, w := range log.Result.Winners {
+			hand.Participant(w.PlayerID).Won = true
+		}
+	}
+
+	return hand, nil
+}

--- a/pkg/playable/bourre/parse_log.go
+++ b/pkg/playable/bourre/parse_log.go
@@ -13,14 +13,13 @@ import (
 // hand when a Bourré game continues across several hands, so a single persisted
 // log can carry a whole chain.
 type persistedLog struct {
-	Parent     *persistedLog      `json:"parent"`
-	Ante       int                `json:"ante"`
-	InitialPot int                `json:"initialPot"`
-	TrumpCard  *deck.Card         `json:"trumpCard"`
-	Seats      []persistedSeat    `json:"seats"`
-	Discards   []persistedDiscard `json:"discards"`
-	Tricks     []persistedTrick   `json:"tricks"`
-	Result     *persistedResult   `json:"result"`
+	Parent    *persistedLog      `json:"parent"`
+	Ante      int                `json:"ante"`
+	TrumpCard *deck.Card         `json:"trumpCard"`
+	Seats     []persistedSeat    `json:"seats"`
+	Discards  []persistedDiscard `json:"discards"`
+	Tricks    []persistedTrick   `json:"tricks"`
+	Result    *persistedResult   `json:"result"`
 }
 
 type persistedSeat struct {
@@ -35,9 +34,8 @@ type persistedDiscard struct {
 }
 
 type persistedTrick struct {
-	Number   int             `json:"number"`
-	Plays    []persistedPlay `json:"plays"`
-	WinnerID int64           `json:"winnerId"`
+	Number int             `json:"number"`
+	Plays  []persistedPlay `json:"plays"`
 }
 
 type persistedPlay struct {
@@ -49,10 +47,8 @@ type persistedPlay struct {
 // which has no JSON tags and exports only PlayerID, so it serializes with the Go
 // field name.
 type persistedResult struct {
-	Winners       []persistedPlayer `json:"Winners"`
-	Folded        []persistedPlayer `json:"Folded"`
-	WinningAmount int               `json:"WinningAmount"`
-	OldPot        int               `json:"OldPot"`
+	Winners []persistedPlayer `json:"Winners"`
+	OldPot  int               `json:"OldPot"`
 }
 
 type persistedPlayer struct {
@@ -101,6 +97,7 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 	folded := make(map[int64]bool, len(log.Discards))
 	for _, d := range log.Discards {
 		if d.Folded {
+			// AddAction records the fold; the map is what ResolveShowdown needs.
 			folded[d.PlayerID] = true
 			hand.AddAction(&gamelog.Action{
 				Street:   "trade-in",
@@ -130,22 +127,18 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 		}
 	}
 
-	// Folding is the only way out of a Bourré hand, so everyone else contested it.
-	contested := 0
-	for _, p := range hand.Participants {
-		if !folded[p.PlayerID] {
-			contested++
-		}
-	}
+	// Folding is the only way out of a Bourré hand, so the shared showdown rule
+	// applies unchanged: everyone who did not fold contested it.
+	//
+	// The winnings map is nil because Bourré names its winners directly, and that
+	// list is authoritative even when the amount is zero — a hand can be won for
+	// nothing when the pot carries. Deriving Won from a payout would lose those.
+	hand.ResolveShowdown(folded, nil)
 
+	// Staying in past the trade-in is the commitment Bourré asks for; there is no
+	// separate wager to opt into.
 	for _, p := range hand.Participants {
-		if folded[p.PlayerID] {
-			p.Folded = true
-			continue
-		}
-
-		p.VoluntarilyPlayed = true
-		p.WentToShowdown = contested > 1
+		p.VoluntarilyPlayed = !p.Folded
 	}
 
 	if log.Result != nil {

--- a/pkg/playable/bourre/parse_log_test.go
+++ b/pkg/playable/bourre/parse_log_test.go
@@ -1,0 +1,124 @@
+package bourre
+
+import (
+	"encoding/json"
+	"testing"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalLog serializes the live gameLog exactly as EndGame persists it, so these
+// tests exercise the real on-disk contract rather than a hand-written
+// approximation of it. Result in particular has no JSON tags, so this pins the
+// Go-field-name encoding the parser relies on.
+func marshalLog(t *testing.T, log *gameLog) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(log)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestParseGameLog(t *testing.T) {
+	winner := NewPlayer(1)
+	folder := NewPlayer(3)
+
+	log := &gameLog{
+		Options:    Options{Ante: 50},
+		Ante:       50,
+		InitialPot: 150,
+		TrumpCard:  deck.CardFromString("14s"),
+		Seats: []*gameLogSeat{
+			{PlayerID: 1, StartingHand: []*deck.Card{deck.CardFromString("13s"), deck.CardFromString("12s")}},
+			{PlayerID: 2, StartingHand: []*deck.Card{deck.CardFromString("3c"), deck.CardFromString("8h")}},
+			{PlayerID: 3, StartingHand: []*deck.Card{deck.CardFromString("2d"), deck.CardFromString("5c")}},
+		},
+		Discards: []*gameLogDiscard{
+			{PlayerID: 1, Discarded: []*deck.Card{deck.CardFromString("12s")}, NewCards: []*deck.Card{deck.CardFromString("11s")}},
+			{PlayerID: 2, Discarded: []*deck.Card{}},
+			{PlayerID: 3, Folded: true},
+		},
+		Tricks: []*gameLogTrick{
+			{
+				Number: 1,
+				Plays: []*gameLogPlay{
+					{PlayerID: 1, Card: deck.CardFromString("13s")},
+					{PlayerID: 2, Card: deck.CardFromString("3c")},
+				},
+				WinnerID: 1,
+			},
+		},
+		Result: &Result{
+			Winners:       []*Player{winner},
+			Folded:        []*Player{folder},
+			WinningAmount: 150,
+			OldPot:        150,
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	assert.Equal(t, 50, hand.AnteCents)
+	assert.Equal(t, 150, hand.PotCents)
+	assert.Equal(t, 1, hand.Rounds)
+	require.Len(t, hand.Board, 1, "the trump card is the shared card")
+	assert.Equal(t, 14, hand.Board[0].Rank)
+
+	p1 := hand.Participant(1)
+	assert.True(t, p1.VoluntarilyPlayed)
+	assert.False(t, p1.Folded)
+	assert.True(t, p1.WentToShowdown)
+	assert.True(t, p1.Won)
+	assert.Equal(t, 1, p1.Counts[gamelog.KindDiscard])
+	assert.Equal(t, 1, p1.Counts[gamelog.KindPlayCard])
+
+	p2 := hand.Participant(2)
+	assert.True(t, p2.VoluntarilyPlayed)
+	assert.True(t, p2.WentToShowdown)
+	assert.False(t, p2.Won)
+
+	// Folding in Bourré happens at the trade-in phase, before any trick.
+	p3 := hand.Participant(3)
+	assert.True(t, p3.Folded)
+	assert.False(t, p3.VoluntarilyPlayed)
+	assert.False(t, p3.WentToShowdown)
+	assert.Equal(t, 1, p3.Counts[gamelog.KindDropOut])
+}
+
+// TestParseGameLog_Continuation covers a chained hand: the parent hands count
+// toward Rounds without their participation being merged into the final hand.
+func TestParseGameLog_Continuation(t *testing.T) {
+	log := &gameLog{
+		Parent: &gameLog{
+			Parent: &gameLog{Ante: 50},
+			Ante:   50,
+		},
+		Ante:  50,
+		Seats: []*gameLogSeat{{PlayerID: 1}, {PlayerID: 2}},
+		Discards: []*gameLogDiscard{
+			{PlayerID: 1, Discarded: []*deck.Card{}},
+			{PlayerID: 2, Discarded: []*deck.Card{}},
+		},
+		Result: &Result{Winners: []*Player{NewPlayer(2)}, OldPot: 400},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, hand.Rounds, "two parents plus the final hand")
+	assert.Len(t, hand.Participants, 2, "parent participation is not merged in")
+	assert.True(t, hand.Participant(2).Won)
+}
+
+func TestParseGameLog_Invalid(t *testing.T) {
+	hand, err := ParseGameLog(json.RawMessage(`{"tricks":42}`))
+	assert.Nil(t, hand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not decode bourre log")
+}

--- a/pkg/playable/gamelog/betting.go
+++ b/pkg/playable/gamelog/betting.go
@@ -1,0 +1,78 @@
+package gamelog
+
+import "mondaynightpoker-server/pkg/deck"
+
+// BettingAction is the persisted form of a logged betting action.
+//
+// Texas Hold'em, Seven Card, and Little L each declare their own gameLogAction
+// struct, but all three record the same fields, so all three decode into this one
+// shape and share the normalization below. Only the name of the phase field
+// differs (a "street" in two of them, a "round" in Little L), which the parsers
+// resolve before handing the actions over.
+type BettingAction struct {
+	Street   string
+	PlayerID int64
+	Action   RawID
+	Amount   int
+	Cards    []*deck.Card
+	AllIn    bool
+}
+
+// ApplyBettingActions normalizes a hand's betting actions onto h, in order.
+//
+// A call, bet, or raise marks the player as having voluntarily played: those are
+// the actions that put money in by choice. Checking does not qualify, which is
+// what keeps a big blind who checks a free preflop out of the VPIP count, and
+// blinds and antes never reach here because they are posted by the pot manager
+// rather than recorded as actions.
+//
+// Actions whose identifier is not recognized are skipped rather than treated as an
+// error, so a log written by a newer game version still yields usable numbers for
+// the actions that are understood.
+func (h *Hand) ApplyBettingActions(actions []BettingAction) {
+	for _, a := range actions {
+		kind, ok := a.Action.Kind()
+		if !ok {
+			continue
+		}
+
+		h.AddAction(&Action{
+			Street:      a.Street,
+			PlayerID:    a.PlayerID,
+			Kind:        kind,
+			AmountCents: a.Amount,
+			Cards:       a.Cards,
+			AllIn:       a.AllIn,
+		})
+
+		if kind == KindCall || kind.IsAggressive() {
+			h.Participant(a.PlayerID).VoluntarilyPlayed = true
+		}
+	}
+}
+
+// ResolveShowdown fills in the outcome fields for a betting game.
+//
+// folded and winnings are keyed by player id: folded reports whether the player
+// gave up the hand, and winnings holds each winner's share of the pot. A player
+// reaches a showdown when they did not fold and at least one opponent also did not
+// fold — a hand everyone else folded out of is won without one, which is why
+// HandsWon and HandsWonAtShowdown are tracked separately.
+func (h *Hand) ResolveShowdown(folded map[int64]bool, winnings map[int64]int) {
+	contested := 0
+	for _, p := range h.Participants {
+		if !folded[p.PlayerID] {
+			contested++
+		}
+	}
+
+	for _, p := range h.Participants {
+		if folded[p.PlayerID] {
+			p.Folded = true
+			continue
+		}
+
+		p.WentToShowdown = contested > 1
+		p.Won = winnings[p.PlayerID] > 0
+	}
+}

--- a/pkg/playable/gamelog/betting.go
+++ b/pkg/playable/gamelog/betting.go
@@ -30,10 +30,42 @@ type BettingAction struct {
 // error, so a log written by a newer game version still yields usable numbers for
 // the actions that are understood.
 func (h *Hand) ApplyBettingActions(actions []BettingAction) {
+	h.ApplyBettingActionsFunc(actions, nil)
+}
+
+// ApplyBettingActionsFunc is ApplyBettingActions with a fallback for action
+// identifiers outside the shared betting vocabulary.
+//
+// Some games interleave non-betting moves into the same action stream as the
+// wagering — Seven Card's Chiggs variant lets a player flip a mushroom or play an
+// antidote in the middle of a street. Those identifiers are declared in the game
+// package, and a game package imports gamelog rather than the other way around, so
+// this package cannot resolve them itself. The fallback lets the game's own parser
+// supply the mapping without either duplicating the bookkeeping below or losing the
+// action's position in the sequence, which is the only record of when it happened
+// relative to the betting.
+//
+// The fallback is consulted only for identifiers RawID.Kind rejects, and an action
+// it resolves never sets VoluntarilyPlayed: these are game mechanics rather than
+// wagers, and counting one as a voluntary play would make VPIP mean something
+// different for the players who happened to be dealt into a variant. An identifier
+// that neither RawID.Kind nor the fallback recognizes is skipped, as it is when
+// there is no fallback at all. Pass nil for fallback to get exactly
+// ApplyBettingActions' behavior.
+func (h *Hand) ApplyBettingActionsFunc(actions []BettingAction, fallback func(RawID) (Kind, bool)) {
 	for _, a := range actions {
-		kind, ok := a.Action.Kind()
-		if !ok {
-			continue
+		// betting records whether the identifier resolved through the shared
+		// vocabulary, because only those actions can put money in voluntarily.
+		kind, betting := a.Action.Kind()
+		if !betting {
+			if fallback == nil {
+				continue
+			}
+
+			var ok bool
+			if kind, ok = fallback(a.Action); !ok {
+				continue
+			}
 		}
 
 		h.AddAction(&Action{
@@ -45,7 +77,7 @@ func (h *Hand) ApplyBettingActions(actions []BettingAction) {
 			AllIn:       a.AllIn,
 		})
 
-		if kind == KindCall || kind.IsAggressive() {
+		if betting && (kind == KindCall || kind.IsAggressive()) {
 			h.Participant(a.PlayerID).VoluntarilyPlayed = true
 		}
 	}

--- a/pkg/playable/gamelog/betting.go
+++ b/pkg/playable/gamelog/betting.go
@@ -5,17 +5,17 @@ import "mondaynightpoker-server/pkg/deck"
 // BettingAction is the persisted form of a logged betting action.
 //
 // Texas Hold'em, Seven Card, and Little L each declare their own gameLogAction
-// struct, but all three record the same fields, so all three decode into this one
-// shape and share the normalization below. Only the name of the phase field
-// differs (a "street" in two of them, a "round" in Little L), which the parsers
-// resolve before handing the actions over.
+// struct, but all three write the same JSON, so the tags here let those parsers
+// decode straight into this type instead of restating the shape. Only Little L
+// differs: it records an integer round rather than a named street, so its parser
+// embeds this type and supplies the street itself.
 type BettingAction struct {
-	Street   string
-	PlayerID int64
-	Action   RawID
-	Amount   int
-	Cards    []*deck.Card
-	AllIn    bool
+	Street   string       `json:"street"`
+	PlayerID int64        `json:"playerId"`
+	Action   RawID        `json:"action"`
+	Amount   int          `json:"amount"`
+	Cards    []*deck.Card `json:"cards"`
+	AllIn    bool         `json:"allIn"`
 }
 
 // ApplyBettingActions normalizes a hand's betting actions onto h, in order.

--- a/pkg/playable/gamelog/gamelog.go
+++ b/pkg/playable/gamelog/gamelog.go
@@ -1,0 +1,230 @@
+// Package gamelog defines a normalized, game-agnostic view of the structured log
+// each game persists to the games.data jsonb column.
+//
+// Every game type writes its own log shape (see the game_log.go file in each game
+// package), and those shapes have nothing in common: Bourré records tricks and a
+// trump card, Guts records per-round in/out decisions, and the poker variants
+// record streets and betting actions. That diversity is correct for replay, but it
+// makes cross-game analysis impossible without a common denominator.
+//
+// A Hand is that denominator. Each game package provides a ParseGameLog function
+// that decodes its own persisted JSON and projects it into a Hand, so the analytics
+// layer can aggregate across every game type without knowing any of them. The
+// projection is lossy on purpose: it keeps who played, what they chose to do, and
+// how the hand resolved, and it drops the game-specific mechanics that cannot be
+// compared across game types.
+//
+// Money is in integer cents throughout, matching the rest of the codebase.
+package gamelog
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"mondaynightpoker-server/pkg/deck"
+)
+
+// Kind is a normalized player action.
+//
+// The betting kinds map one-to-one onto poker/action.Action. The remaining kinds
+// exist so games without a betting round still describe their decisions in the
+// same vocabulary: Guts players declare in or out, Bourré players fold or play
+// cards to tricks, and Pass the Poop players stay or trade.
+type Kind string
+
+// Normalized action kinds.
+const (
+	// KindFold is a player surrendering their claim on the pot. Bourré's
+	// fold-at-trade-in and Guts' "out" declaration both normalize to KindDropOut
+	// rather than KindFold, because neither forfeits money already wagered.
+	KindFold  Kind = "fold"
+	KindCheck Kind = "check"
+	KindCall  Kind = "call"
+	KindBet   Kind = "bet"
+	KindRaise Kind = "raise"
+
+	// KindDiscard and KindTrade are card-exchange actions.
+	KindDiscard Kind = "discard"
+	KindTrade   Kind = "trade"
+
+	// KindStayIn and KindDropOut are commitment decisions in games that have no
+	// betting round: the player either commits to contest the pot or steps aside.
+	KindStayIn  Kind = "stay-in"
+	KindDropOut Kind = "drop-out"
+
+	// KindPlayCard is a card played to a trick (Bourré).
+	KindPlayCard Kind = "play-card"
+
+	// KindPass is declining to act when passing is a distinct choice from checking
+	// (Acey Deucey's pass, which forfeits the turn without a wager).
+	KindPass Kind = "pass"
+)
+
+// IsAggressive reports whether the action puts money in voluntarily and applies
+// pressure: a bet or a raise. It backs the aggression factor, which is the ratio
+// of aggressive actions to calls.
+func (k Kind) IsAggressive() bool {
+	return k == KindBet || k == KindRaise
+}
+
+// Action is a single normalized player action within a hand.
+type Action struct {
+	// Sequence is the action's zero-based position in the hand, assigned by the
+	// parser in the order the actions were recorded.
+	Sequence int `json:"sequence"`
+	// Street is the phase of the hand the action occurred in. The vocabulary is
+	// game-specific ("preflop"/"flop" for hold'em, "third-street" for seven card,
+	// "round-1" for the round-based games); it is descriptive, not comparable
+	// across game types.
+	Street      string       `json:"street,omitempty"`
+	PlayerID    int64        `json:"playerId"`
+	Kind        Kind         `json:"kind"`
+	AmountCents int          `json:"amountCents,omitempty"`
+	Cards       []*deck.Card `json:"cards,omitempty"`
+	AllIn       bool         `json:"allIn,omitempty"`
+}
+
+// Participation is one player's involvement in one hand.
+//
+// VoluntarilyPlayed is the cross-game analogue of VPIP: it is true when the player
+// made a choice that committed them to contest the pot beyond whatever the game
+// forced them to post. Each parser decides what qualifies, because only it knows
+// which contributions were forced (antes and blinds never count).
+type Participation struct {
+	PlayerID      int64        `json:"playerId"`
+	StartingCards []*deck.Card `json:"startingCards,omitempty"`
+	FinalCards    []*deck.Card `json:"finalCards,omitempty"`
+
+	VoluntarilyPlayed bool `json:"voluntarilyPlayed"`
+	Folded            bool `json:"folded"`
+	WentToShowdown    bool `json:"wentToShowdown"`
+	Won               bool `json:"won"`
+
+	// AmountWageredCents is what the player put into the pot through their own
+	// actions during the hand. It excludes the forced ante and is not the same as
+	// their net result, which comes from the ledger rather than the log.
+	AmountWageredCents int `json:"amountWageredCents"`
+
+	// Counts tallies the player's actions by kind.
+	Counts map[Kind]int `json:"counts,omitempty"`
+}
+
+// count records one action of the given kind.
+func (p *Participation) count(k Kind) {
+	if p.Counts == nil {
+		p.Counts = make(map[Kind]int)
+	}
+	p.Counts[k]++
+}
+
+// Hand is the normalized summary of one completed game.
+type Hand struct {
+	// GameType is the games.game_type identifier (e.g. "texas-hold-em").
+	GameType string `json:"gameType"`
+	// Variant distinguishes sub-games within a game type (e.g. "pineapple" for
+	// hold'em, "baseball" for seven card). It is empty when the game type has no
+	// variants.
+	Variant string `json:"variant,omitempty"`
+
+	AnteCents int `json:"anteCents"`
+	PotCents  int `json:"potCents"`
+	// Rounds is the number of distinct rounds or hands the game ran. Games that
+	// resolve in a single pass report 1.
+	Rounds int `json:"rounds"`
+	// Board is the shared/community cards, if the game has any.
+	Board []*deck.Card `json:"board,omitempty"`
+
+	Participants []*Participation `json:"participants"`
+	Actions      []*Action        `json:"actions"`
+}
+
+// Participant returns the participation record for the player, creating it if the
+// hand does not have one yet. Parsers use it to accumulate a player's involvement
+// without tracking insertion order themselves.
+func (h *Hand) Participant(playerID int64) *Participation {
+	for _, p := range h.Participants {
+		if p.PlayerID == playerID {
+			return p
+		}
+	}
+
+	p := &Participation{PlayerID: playerID}
+	h.Participants = append(h.Participants, p)
+	return p
+}
+
+// AddAction appends a normalized action to the hand and reflects it in the acting
+// player's participation record: the action is counted, any wagered amount is
+// accumulated, and a fold is recorded.
+//
+// It deliberately does not infer VoluntarilyPlayed. Whether an action was
+// voluntary depends on game rules the Hand does not model (a hold'em big blind
+// posts a bet without choosing to), so each parser sets that flag itself.
+func (h *Hand) AddAction(a *Action) {
+	a.Sequence = len(h.Actions)
+	h.Actions = append(h.Actions, a)
+
+	p := h.Participant(a.PlayerID)
+	p.count(a.Kind)
+	p.AmountWageredCents += a.AmountCents
+
+	switch a.Kind {
+	case KindFold, KindDropOut:
+		p.Folded = true
+	}
+}
+
+// RawID decodes an identifier from the persisted log that may be stored either as
+// a bare JSON string or as an object carrying an "id" field.
+//
+// Several game packages define MarshalJSON on their enum types to emit
+// {"id":"fold","name":"Fold"} but never define a matching UnmarshalJSON, so those
+// values do not round-trip back into their original Go type. Actions and Texas
+// Hold'em variants are both stored that way. RawID accepts either form, so parsing
+// works regardless of which encoding produced the log.
+type RawID string
+
+// UnmarshalJSON implements json.Unmarshaler, accepting either a bare string or an
+// {"id": ...} object.
+func (r *RawID) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*r = RawID(s)
+		return nil
+	}
+
+	var obj struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return fmt.Errorf("could not decode identifier: %w", err)
+	}
+
+	*r = RawID(obj.ID)
+	return nil
+}
+
+// Kind maps the persisted action identifier onto a normalized Kind. Unrecognized
+// identifiers return false so a parser can decide whether to skip the action or
+// fail; a log written by a newer game version should not break analysis of the
+// actions that are understood.
+func (r RawID) Kind() (Kind, bool) {
+	switch string(r) {
+	case "fold":
+		return KindFold, true
+	case "check":
+		return KindCheck, true
+	case "call":
+		return KindCall, true
+	case "bet":
+		return KindBet, true
+	case "raise":
+		return KindRaise, true
+	case "discard":
+		return KindDiscard, true
+	case "trade":
+		return KindTrade, true
+	}
+
+	return "", false
+}

--- a/pkg/playable/gamelog/gamelog.go
+++ b/pkg/playable/gamelog/gamelog.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/poker/action"
 )
 
 // Kind is a normalized player action.
@@ -138,14 +139,25 @@ type Hand struct {
 	Actions      []*Action        `json:"actions"`
 }
 
-// Participant returns the participation record for the player, creating it if the
-// hand does not have one yet. Parsers use it to accumulate a player's involvement
-// without tracking insertion order themselves.
-func (h *Hand) Participant(playerID int64) *Participation {
+// FindParticipant returns the participation record for the player, or nil when the
+// hand does not name them. Use it to ask whether a player took part; use
+// Participant to accumulate their involvement.
+func (h *Hand) FindParticipant(playerID int64) *Participation {
 	for _, p := range h.Participants {
 		if p.PlayerID == playerID {
 			return p
 		}
+	}
+
+	return nil
+}
+
+// Participant returns the participation record for the player, creating it if the
+// hand does not have one yet. Parsers use it to accumulate a player's involvement
+// without tracking insertion order themselves.
+func (h *Hand) Participant(playerID int64) *Participation {
+	if p := h.FindParticipant(playerID); p != nil {
+		return p
 	}
 
 	p := &Participation{PlayerID: playerID}
@@ -208,21 +220,27 @@ func (r *RawID) UnmarshalJSON(b []byte) error {
 // identifiers return false so a parser can decide whether to skip the action or
 // fail; a log written by a newer game version should not break analysis of the
 // actions that are understood.
+//
+// The cases are the poker/action constants rather than string literals, so
+// renaming one there is a compile error here instead of a silently unrecognized
+// action. Seven Card declares its own action type with the same identifiers and
+// cannot be referenced from this package (it imports gamelog), but its parser
+// feeds the same strings through here.
 func (r RawID) Kind() (Kind, bool) {
-	switch string(r) {
-	case "fold":
+	switch action.Action(r) {
+	case action.Fold:
 		return KindFold, true
-	case "check":
+	case action.Check:
 		return KindCheck, true
-	case "call":
+	case action.Call:
 		return KindCall, true
-	case "bet":
+	case action.Bet:
 		return KindBet, true
-	case "raise":
+	case action.Raise:
 		return KindRaise, true
-	case "discard":
+	case action.Discard:
 		return KindDiscard, true
-	case "trade":
+	case action.Trade:
 		return KindTrade, true
 	}
 

--- a/pkg/playable/gamelog/gamelog_test.go
+++ b/pkg/playable/gamelog/gamelog_test.go
@@ -136,6 +136,61 @@ func TestHand_ApplyBettingActions(t *testing.T) {
 	assert.True(t, hand.Participant(4).Folded)
 }
 
+func TestHand_ApplyBettingActionsFunc(t *testing.T) {
+	hand := &Hand{}
+	hand.ApplyBettingActionsFunc([]BettingAction{
+		{Street: "third-street", PlayerID: 1, Action: "bet", Amount: 50},
+		{Street: "third-street", PlayerID: 2, Action: "flip-mushroom"},
+		{Street: "third-street", PlayerID: 2, Action: "call", Amount: 50},
+		// Still unknown to both the shared vocabulary and the fallback.
+		{Street: "third-street", PlayerID: 3, Action: "teleport"},
+	}, func(raw RawID) (Kind, bool) {
+		if raw == "flip-mushroom" {
+			return KindPlayCard, true
+		}
+
+		return "", false
+	})
+
+	// The fallback action keeps its position between the two betting actions.
+	require.Len(t, hand.Actions, 3)
+	assert.Equal(t, KindPlayCard, hand.Actions[1].Kind)
+	assert.Equal(t, int64(2), hand.Actions[1].PlayerID)
+	assert.Equal(t, "third-street", hand.Actions[1].Street)
+	assert.Equal(t, 1, hand.Actions[1].Sequence)
+	assert.Equal(t, KindCall, hand.Actions[2].Kind)
+
+	// The fallback is never what makes a player voluntarily played; the call is.
+	assert.True(t, hand.Participant(2).VoluntarilyPlayed)
+	assert.Equal(t, 50, hand.Participant(2).AmountWageredCents)
+	assert.Nil(t, hand.FindParticipant(3), "the unresolved action added nobody")
+}
+
+func TestHand_ApplyBettingActionsFunc_FallbackIsNotVoluntary(t *testing.T) {
+	hand := &Hand{}
+	// A fallback that resolves to a kind the betting path would treat as voluntary
+	// must still not set the flag: only the shared vocabulary can.
+	hand.ApplyBettingActionsFunc([]BettingAction{
+		{PlayerID: 1, Action: "flip-mushroom", Amount: 0},
+	}, func(RawID) (Kind, bool) {
+		return KindRaise, true
+	})
+
+	require.Len(t, hand.Actions, 1)
+	assert.False(t, hand.Participant(1).VoluntarilyPlayed)
+}
+
+func TestHand_ApplyBettingActionsFunc_NilFallback(t *testing.T) {
+	hand := &Hand{}
+	hand.ApplyBettingActionsFunc([]BettingAction{
+		{PlayerID: 1, Action: "check"},
+		{PlayerID: 2, Action: "flip-mushroom"},
+	}, nil)
+
+	require.Len(t, hand.Actions, 1, "without a fallback the unknown action is skipped")
+	assert.Equal(t, KindCheck, hand.Actions[0].Kind)
+}
+
 func TestHand_ResolveShowdown(t *testing.T) {
 	t.Run("contested", func(t *testing.T) {
 		hand := &Hand{}

--- a/pkg/playable/gamelog/gamelog_test.go
+++ b/pkg/playable/gamelog/gamelog_test.go
@@ -1,0 +1,173 @@
+package gamelog
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawID_UnmarshalJSON(t *testing.T) {
+	// The object form is what the game packages' MarshalJSON implementations
+	// actually write; the bare string is the form a plain string field produces.
+	testCases := []struct {
+		name string
+		raw  string
+		want RawID
+	}{
+		{"object form", `{"id":"fold","name":"Fold"}`, "fold"},
+		{"object form with extra fields", `{"id":"pineapple","name":"Pineapple","holeCards":3}`, "pineapple"},
+		{"bare string", `"raise"`, "raise"},
+		{"empty string", `""`, ""},
+		{"object without id", `{"name":"Fold"}`, ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got RawID
+			require.NoError(t, json.Unmarshal([]byte(tc.raw), &got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRawID_UnmarshalJSON_Invalid(t *testing.T) {
+	var got RawID
+	err := json.Unmarshal([]byte(`[1,2,3]`), &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not decode identifier")
+}
+
+func TestRawID_Kind(t *testing.T) {
+	for raw, want := range map[RawID]Kind{
+		"fold":    KindFold,
+		"check":   KindCheck,
+		"call":    KindCall,
+		"bet":     KindBet,
+		"raise":   KindRaise,
+		"discard": KindDiscard,
+		"trade":   KindTrade,
+	} {
+		got, ok := raw.Kind()
+		assert.True(t, ok, "%s should be known", raw)
+		assert.Equal(t, want, got)
+	}
+
+	// An identifier from a newer game version must not be mistaken for a known one.
+	got, ok := RawID("teleport").Kind()
+	assert.False(t, ok)
+	assert.Equal(t, Kind(""), got)
+}
+
+func TestKind_IsAggressive(t *testing.T) {
+	assert.True(t, KindBet.IsAggressive())
+	assert.True(t, KindRaise.IsAggressive())
+	assert.False(t, KindCall.IsAggressive())
+	assert.False(t, KindCheck.IsAggressive())
+	assert.False(t, KindFold.IsAggressive())
+}
+
+func TestHand_Participant(t *testing.T) {
+	hand := &Hand{}
+
+	first := hand.Participant(7)
+	assert.Equal(t, int64(7), first.PlayerID)
+	assert.Len(t, hand.Participants, 1)
+
+	// Asking again returns the same record rather than adding a duplicate.
+	again := hand.Participant(7)
+	assert.Same(t, first, again)
+	assert.Len(t, hand.Participants, 1)
+
+	hand.Participant(8)
+	assert.Len(t, hand.Participants, 2)
+}
+
+func TestHand_AddAction(t *testing.T) {
+	hand := &Hand{}
+
+	hand.AddAction(&Action{PlayerID: 1, Kind: KindBet, AmountCents: 50})
+	hand.AddAction(&Action{PlayerID: 1, Kind: KindCall, AmountCents: 25})
+	hand.AddAction(&Action{PlayerID: 2, Kind: KindFold})
+
+	// Sequence is assigned in insertion order.
+	require.Len(t, hand.Actions, 3)
+	assert.Equal(t, 0, hand.Actions[0].Sequence)
+	assert.Equal(t, 2, hand.Actions[2].Sequence)
+
+	p1 := hand.Participant(1)
+	assert.Equal(t, 75, p1.AmountWageredCents)
+	assert.Equal(t, 1, p1.Counts[KindBet])
+	assert.Equal(t, 1, p1.Counts[KindCall])
+	assert.False(t, p1.Folded)
+
+	// AddAction records the fold but leaves VoluntarilyPlayed to the parser, which
+	// is the only thing that knows which contributions were forced.
+	p2 := hand.Participant(2)
+	assert.True(t, p2.Folded)
+	assert.False(t, p2.VoluntarilyPlayed)
+}
+
+func TestHand_AddAction_DropOutFolds(t *testing.T) {
+	hand := &Hand{}
+	hand.AddAction(&Action{PlayerID: 1, Kind: KindDropOut})
+
+	assert.True(t, hand.Participant(1).Folded, "dropping out is folding")
+}
+
+func TestHand_ApplyBettingActions(t *testing.T) {
+	hand := &Hand{}
+	hand.ApplyBettingActions([]BettingAction{
+		{Street: "preflop", PlayerID: 1, Action: "raise", Amount: 100},
+		{Street: "preflop", PlayerID: 2, Action: "call", Amount: 100},
+		{Street: "preflop", PlayerID: 3, Action: "check"},
+		{Street: "preflop", PlayerID: 4, Action: "fold"},
+		// An action from a newer game version is skipped, not fatal.
+		{Street: "preflop", PlayerID: 5, Action: "teleport"},
+	})
+
+	require.Len(t, hand.Actions, 4, "the unknown action is skipped")
+
+	assert.True(t, hand.Participant(1).VoluntarilyPlayed, "raising is voluntary")
+	assert.True(t, hand.Participant(2).VoluntarilyPlayed, "calling is voluntary")
+	assert.False(t, hand.Participant(3).VoluntarilyPlayed, "checking is free")
+	assert.False(t, hand.Participant(4).VoluntarilyPlayed, "folding is not playing")
+	assert.True(t, hand.Participant(4).Folded)
+}
+
+func TestHand_ResolveShowdown(t *testing.T) {
+	t.Run("contested", func(t *testing.T) {
+		hand := &Hand{}
+		hand.Participant(1)
+		hand.Participant(2)
+		hand.Participant(3)
+
+		hand.ResolveShowdown(
+			map[int64]bool{3: true},
+			map[int64]int{1: 300},
+		)
+
+		assert.True(t, hand.Participant(1).WentToShowdown)
+		assert.True(t, hand.Participant(1).Won)
+		assert.True(t, hand.Participant(2).WentToShowdown)
+		assert.False(t, hand.Participant(2).Won)
+		assert.True(t, hand.Participant(3).Folded)
+		assert.False(t, hand.Participant(3).WentToShowdown)
+	})
+
+	t.Run("uncontested", func(t *testing.T) {
+		hand := &Hand{}
+		hand.Participant(1)
+		hand.Participant(2)
+
+		hand.ResolveShowdown(
+			map[int64]bool{2: true},
+			map[int64]int{1: 100},
+		)
+
+		// Everyone else folded, so the pot was won without a showdown.
+		assert.True(t, hand.Participant(1).Won)
+		assert.False(t, hand.Participant(1).WentToShowdown)
+	})
+}

--- a/pkg/playable/gamelog/tendencies.go
+++ b/pkg/playable/gamelog/tendencies.go
@@ -1,0 +1,109 @@
+package gamelog
+
+// Tendencies is one player's behavioral profile aggregated over many hands.
+//
+// It answers how someone plays rather than how much they won: the ledger already
+// records the money. Every field is a raw count so callers can derive whatever
+// rates they want and, more importantly, so a caller can tell the difference
+// between "folds 100% of the time" over three hands and over three hundred.
+type Tendencies struct {
+	// HandsPlayed is the number of hands the player appeared in.
+	HandsPlayed int
+	// HandsVoluntarilyPlayed is the number of hands where the player chose to
+	// commit beyond any forced ante or blind. This is the cross-game VPIP.
+	HandsVoluntarilyPlayed int
+	// HandsFolded is the number of hands the player folded or dropped out of.
+	HandsFolded int
+	// HandsToShowdown is the number of hands the player was still contesting when
+	// the hand resolved.
+	HandsToShowdown int
+	// HandsWonAtShowdown is the subset of HandsToShowdown the player won.
+	HandsWonAtShowdown int
+	// HandsWon is every hand the player won, including those won without a
+	// showdown because everyone else folded.
+	HandsWon int
+
+	// Action tallies across every hand.
+	Bets     int
+	Raises   int
+	Calls    int
+	Checks   int
+	Folds    int
+	Discards int
+	Trades   int
+
+	// AmountWageredCents is the total the player put into pots through their own
+	// actions, excluding forced antes.
+	AmountWageredCents int
+}
+
+// Add folds a single hand's participation record into the aggregate.
+func (t *Tendencies) Add(p *Participation) {
+	if p == nil {
+		return
+	}
+
+	t.HandsPlayed++
+	if p.VoluntarilyPlayed {
+		t.HandsVoluntarilyPlayed++
+	}
+	if p.Folded {
+		t.HandsFolded++
+	}
+	if p.WentToShowdown {
+		t.HandsToShowdown++
+		if p.Won {
+			t.HandsWonAtShowdown++
+		}
+	}
+	if p.Won {
+		t.HandsWon++
+	}
+
+	t.AmountWageredCents += p.AmountWageredCents
+
+	t.Bets += p.Counts[KindBet]
+	t.Raises += p.Counts[KindRaise]
+	t.Calls += p.Counts[KindCall]
+	t.Checks += p.Counts[KindCheck]
+	t.Folds += p.Counts[KindFold] + p.Counts[KindDropOut]
+	t.Discards += p.Counts[KindDiscard]
+	t.Trades += p.Counts[KindTrade]
+}
+
+// AggressionFactor is the ratio of aggressive actions (bets and raises) to calls,
+// the standard measure of whether a player drives betting or follows it.
+//
+// It is undefined when the player has never called: dividing by zero would report
+// an infinitely aggressive player on the strength of a single bet. The second
+// return value is false in that case, and callers should omit the statistic rather
+// than substitute a number.
+func (t *Tendencies) AggressionFactor() (float64, bool) {
+	if t.Calls == 0 {
+		return 0, false
+	}
+
+	return float64(t.Bets+t.Raises) / float64(t.Calls), true
+}
+
+// Rate divides count by HandsPlayed, reporting false when no hands were played.
+// Callers use it for the participation rates (VPIP, fold rate, showdown rate) so
+// the zero-hands case is handled the same way everywhere.
+func (t *Tendencies) Rate(count int) (float64, bool) {
+	if t.HandsPlayed == 0 {
+		return 0, false
+	}
+
+	return float64(count) / float64(t.HandsPlayed), true
+}
+
+// ShowdownWinRate is the share of contested showdowns the player won, reporting
+// false when they never reached one. It is deliberately not a Rate over
+// HandsPlayed: folding more does not make someone better at showdowns.
+func (t *Tendencies) ShowdownWinRate() (float64, bool) {
+	if t.HandsToShowdown == 0 {
+		return 0, false
+	}
+
+	return float64(t.HandsWonAtShowdown) / float64(t.HandsToShowdown), true
+}

--- a/pkg/playable/gamelog/tendencies_test.go
+++ b/pkg/playable/gamelog/tendencies_test.go
@@ -1,0 +1,94 @@
+package gamelog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTendencies_Add(t *testing.T) {
+	var got Tendencies
+
+	got.Add(&Participation{
+		PlayerID:           1,
+		VoluntarilyPlayed:  true,
+		WentToShowdown:     true,
+		Won:                true,
+		AmountWageredCents: 250,
+		Counts:             map[Kind]int{KindBet: 1, KindRaise: 1, KindCall: 2, KindCheck: 3},
+	})
+	got.Add(&Participation{
+		PlayerID: 1,
+		Folded:   true,
+		Counts:   map[Kind]int{KindFold: 1},
+	})
+	got.Add(&Participation{
+		PlayerID:          1,
+		VoluntarilyPlayed: true,
+		WentToShowdown:    true,
+		Counts:            map[Kind]int{KindCall: 1, KindDropOut: 1},
+	})
+
+	assert.Equal(t, 3, got.HandsPlayed)
+	assert.Equal(t, 2, got.HandsVoluntarilyPlayed)
+	assert.Equal(t, 1, got.HandsFolded)
+	assert.Equal(t, 2, got.HandsToShowdown)
+	assert.Equal(t, 1, got.HandsWonAtShowdown)
+	assert.Equal(t, 1, got.HandsWon)
+	assert.Equal(t, 250, got.AmountWageredCents)
+
+	assert.Equal(t, 1, got.Bets)
+	assert.Equal(t, 1, got.Raises)
+	assert.Equal(t, 3, got.Calls)
+	assert.Equal(t, 3, got.Checks)
+	assert.Equal(t, 2, got.Folds, "drop-outs count as folds")
+}
+
+func TestTendencies_Add_Nil(t *testing.T) {
+	var got Tendencies
+	got.Add(nil)
+
+	assert.Zero(t, got.HandsPlayed)
+}
+
+func TestTendencies_AggressionFactor(t *testing.T) {
+	got := Tendencies{Bets: 3, Raises: 3, Calls: 2}
+	factor, ok := got.AggressionFactor()
+	assert.True(t, ok)
+	assert.Equal(t, 3.0, factor)
+
+	// A player who has never called has no defined aggression factor: reporting
+	// one would divide by zero and imply infinite aggression from a single bet.
+	never := Tendencies{Bets: 5}
+	factor, ok = never.AggressionFactor()
+	assert.False(t, ok)
+	assert.Zero(t, factor)
+}
+
+func TestTendencies_Rate(t *testing.T) {
+	got := Tendencies{HandsPlayed: 4, HandsVoluntarilyPlayed: 1}
+
+	rate, ok := got.Rate(got.HandsVoluntarilyPlayed)
+	assert.True(t, ok)
+	assert.Equal(t, 0.25, rate)
+
+	var empty Tendencies
+	rate, ok = empty.Rate(0)
+	assert.False(t, ok)
+	assert.Zero(t, rate)
+}
+
+func TestTendencies_ShowdownWinRate(t *testing.T) {
+	got := Tendencies{HandsPlayed: 10, HandsToShowdown: 4, HandsWonAtShowdown: 3}
+
+	// The denominator is showdowns reached, not hands played: folding more often
+	// does not make someone better at showdowns.
+	rate, ok := got.ShowdownWinRate()
+	assert.True(t, ok)
+	assert.Equal(t, 0.75, rate)
+
+	nitty := Tendencies{HandsPlayed: 50}
+	rate, ok = nitty.ShowdownWinRate()
+	assert.False(t, ok)
+	assert.Zero(t, rate)
+}

--- a/pkg/playable/guts/parse_log.go
+++ b/pkg/playable/guts/parse_log.go
@@ -1,0 +1,154 @@
+package guts
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+)
+
+// persistedLog mirrors the JSON written by gameLog.
+//
+// The options field has no struct tags on the live type, so it serializes with Go
+// field names rather than lowercased JSON ones — hence the capitalized tag below.
+type persistedLog struct {
+	Options struct {
+		Ante int `json:"Ante"`
+	} `json:"options"`
+	InitialPot int              `json:"initialPot"`
+	Players    []int64          `json:"players"`
+	Rounds     []persistedRound `json:"rounds"`
+}
+
+type persistedRound struct {
+	Round     int                 `json:"round"`
+	Pot       int                 `json:"pot"`
+	Seats     []persistedSeat     `json:"seats"`
+	Decisions []persistedDecision `json:"decisions"`
+	Trades    []persistedTrade    `json:"trades"`
+	Result    *persistedShowdown  `json:"result"`
+}
+
+type persistedSeat struct {
+	PlayerID int64        `json:"playerId"`
+	Cards    []*deck.Card `json:"cards"`
+}
+
+type persistedDecision struct {
+	PlayerID int64 `json:"playerId"`
+	In       bool  `json:"in"`
+}
+
+type persistedTrade struct {
+	PlayerID     int64        `json:"playerId"`
+	DiscardedOut []*deck.Card `json:"discardedOut"`
+	NewCards     []*deck.Card `json:"newCards"`
+}
+
+type persistedShowdown struct {
+	Winners    []int64         `json:"winners"`
+	PlayersIn  []int64         `json:"playersIn"`
+	FinalHands []persistedSeat `json:"finalHands"`
+}
+
+// ParseGameLog decodes a persisted Guts log into a normalized hand.
+//
+// A Guts game runs one or more rounds, and the normalized hand covers the whole
+// game rather than a single round. A player counts as having voluntarily played if
+// they declared in on any round, and as having folded only if they declared out on
+// every round they were dealt into — staying out of one round of a five-round game
+// is not the same as folding the game.
+//
+// Starting cards are taken from the first round and final cards from the last
+// showdown, so a multi-round game reports the hand the player began with and the
+// hand they finished on.
+func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	var log persistedLog
+	if err := json.Unmarshal(raw, &log); err != nil {
+		return nil, fmt.Errorf("could not decode guts log: %w", err)
+	}
+
+	hand := &gamelog.Hand{
+		AnteCents: log.Options.Ante,
+		Rounds:    len(log.Rounds),
+	}
+
+	for _, id := range log.Players {
+		hand.Participant(id)
+	}
+
+	// declaredOut tracks players who have chosen out at least once, so a player who
+	// never once declared in can be marked as having folded the game.
+	declaredIn := make(map[int64]bool)
+
+	for i, round := range log.Rounds {
+		street := "round-" + strconv.Itoa(round.Round)
+		hand.PotCents = round.Pot
+
+		if i == 0 {
+			for _, seat := range round.Seats {
+				hand.Participant(seat.PlayerID).StartingCards = seat.Cards
+			}
+		}
+
+		for _, d := range round.Decisions {
+			kind := gamelog.KindDropOut
+			if d.In {
+				kind = gamelog.KindStayIn
+				declaredIn[d.PlayerID] = true
+			}
+
+			hand.AddAction(&gamelog.Action{
+				Street:   street,
+				PlayerID: d.PlayerID,
+				Kind:     kind,
+			})
+		}
+
+		for _, t := range round.Trades {
+			hand.AddAction(&gamelog.Action{
+				Street:   street,
+				PlayerID: t.PlayerID,
+				Kind:     gamelog.KindTrade,
+				Cards:    t.DiscardedOut,
+			})
+		}
+
+		applyShowdown(hand, round.Result)
+	}
+
+	for _, p := range hand.Participants {
+		p.VoluntarilyPlayed = declaredIn[p.PlayerID]
+		// AddAction marks a player folded on any drop-out; only a player who never
+		// declared in actually sat the whole game out.
+		p.Folded = !declaredIn[p.PlayerID]
+	}
+
+	return hand, nil
+}
+
+// applyShowdown folds one round's result into the hand's participation records.
+// Reaching a showdown requires more than one player to have declared in;
+// a lone player takes the pot without contest.
+func applyShowdown(hand *gamelog.Hand, result *persistedShowdown) {
+	if result == nil {
+		return
+	}
+
+	contested := len(result.PlayersIn) > 1
+	for _, id := range result.PlayersIn {
+		if contested {
+			hand.Participant(id).WentToShowdown = true
+		}
+	}
+
+	for _, id := range result.Winners {
+		hand.Participant(id).Won = true
+	}
+
+	for _, seat := range result.FinalHands {
+		hand.Participant(seat.PlayerID).FinalCards = seat.Cards
+	}
+}

--- a/pkg/playable/guts/parse_log.go
+++ b/pkg/playable/guts/parse_log.go
@@ -17,9 +17,8 @@ type persistedLog struct {
 	Options struct {
 		Ante int `json:"Ante"`
 	} `json:"options"`
-	InitialPot int              `json:"initialPot"`
-	Players    []int64          `json:"players"`
-	Rounds     []persistedRound `json:"rounds"`
+	Players []int64          `json:"players"`
+	Rounds  []persistedRound `json:"rounds"`
 }
 
 type persistedRound struct {
@@ -44,7 +43,6 @@ type persistedDecision struct {
 type persistedTrade struct {
 	PlayerID     int64        `json:"playerId"`
 	DiscardedOut []*deck.Card `json:"discardedOut"`
-	NewCards     []*deck.Card `json:"newCards"`
 }
 
 type persistedShowdown struct {
@@ -79,10 +77,6 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 		hand.Participant(id)
 	}
 
-	// declaredOut tracks players who have chosen out at least once, so a player who
-	// never once declared in can be marked as having folded the game.
-	declaredIn := make(map[int64]bool)
-
 	for i, round := range log.Rounds {
 		street := "round-" + strconv.Itoa(round.Round)
 		hand.PotCents = round.Pot
@@ -97,7 +91,6 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 			kind := gamelog.KindDropOut
 			if d.In {
 				kind = gamelog.KindStayIn
-				declaredIn[d.PlayerID] = true
 			}
 
 			hand.AddAction(&gamelog.Action{
@@ -119,11 +112,14 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 		applyShowdown(hand, round.Result)
 	}
 
+	// A stay-in action is recorded exactly when a player declared in, so the tally
+	// already answers this and no parallel map is needed. AddAction marks a player
+	// folded on any drop-out; only a player who never once declared in actually sat
+	// the whole game out.
 	for _, p := range hand.Participants {
-		p.VoluntarilyPlayed = declaredIn[p.PlayerID]
-		// AddAction marks a player folded on any drop-out; only a player who never
-		// declared in actually sat the whole game out.
-		p.Folded = !declaredIn[p.PlayerID]
+		declaredIn := p.Counts[gamelog.KindStayIn] > 0
+		p.VoluntarilyPlayed = declaredIn
+		p.Folded = !declaredIn
 	}
 
 	return hand, nil
@@ -137,9 +133,8 @@ func applyShowdown(hand *gamelog.Hand, result *persistedShowdown) {
 		return
 	}
 
-	contested := len(result.PlayersIn) > 1
-	for _, id := range result.PlayersIn {
-		if contested {
+	if len(result.PlayersIn) > 1 {
+		for _, id := range result.PlayersIn {
 			hand.Participant(id).WentToShowdown = true
 		}
 	}

--- a/pkg/playable/guts/parse_log_e2e_test.go
+++ b/pkg/playable/guts/parse_log_e2e_test.go
@@ -1,0 +1,106 @@
+package guts
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"mondaynightpoker-server/pkg/playable"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseGameLog_EndToEnd drives a real game through the engine and parses the
+// log it actually persists.
+//
+// The other parser tests build the log struct directly, which pins the encoding
+// but assumes the game populates those fields during play. This one closes that
+// gap: it deals through Game.Deal, submits real decisions via Game.Action, takes
+// the payload from GetEndOfGameDetails exactly as EndGame would, and marshals it
+// the way the jsonb column stores it. If the engine ever stops recording a
+// decision or a showdown, this fails even though the round-trip tests would not.
+func TestParseGameLog_EndToEnd(t *testing.T) {
+	g, err := NewGame(logrus.StandardLogger(), []int64{1, 2, 3}, DefaultOptions())
+	require.NoError(t, err)
+	require.NoError(t, g.Deal())
+
+	// Round one is contested by players 1 and 3; player 2 steps aside. A contested
+	// round leaves the pot to carry, so every later round is taken uncontested by
+	// player 1, which ends the game.
+	round := 0
+	decide := func() {
+		round++
+		for _, p := range g.participants {
+			if !g.pendingDecisions[p.PlayerID] {
+				continue
+			}
+
+			in := p.PlayerID == 1 || (round == 1 && p.PlayerID == 3)
+			_, _, err := g.Action(p.PlayerID, &playable.PayloadIn{
+				Action:         "decide",
+				AdditionalData: playable.AdditionalData{"in": in},
+			})
+			require.NoError(t, err, "player %d, round %d", p.PlayerID, round)
+		}
+	}
+
+	// Guts settles each round on a timer. Pull the pending action's deadline into
+	// the past so the game runs forward without the test sleeping.
+	for i := 0; i < 50 && !g.done; i++ {
+		if g.phase == PhaseDeclaration && len(g.pendingDecisions) > 0 {
+			decide()
+		}
+		if g.pendingDealerAction != nil {
+			g.pendingDealerAction.ExecuteAfter = time.Now().Add(-time.Second)
+		}
+		if _, err := g.Tick(); err != nil {
+			require.NoError(t, err)
+		}
+	}
+
+	details, over := g.GetEndOfGameDetails()
+	require.True(t, over, "the game should have finished")
+	require.NotNil(t, details)
+
+	// Persist and re-read exactly as EndGame and the analytics path do.
+	raw, err := json.Marshal(details.Log)
+	require.NoError(t, err)
+
+	hand, err := ParseGameLog(raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, DefaultOptions().Ante, hand.AnteCents)
+	assert.Len(t, hand.Participants, 3)
+	assert.GreaterOrEqual(t, hand.Rounds, 1)
+
+	// The decisions the engine recorded must survive into the normalized hand.
+	assert.True(t, hand.Participant(1).VoluntarilyPlayed)
+	assert.True(t, hand.Participant(3).VoluntarilyPlayed)
+
+	// Player 2 declared out in every round, so they folded the game and the engine
+	// recorded one drop-out per round they were dealt into.
+	out := hand.Participant(2)
+	assert.False(t, out.VoluntarilyPlayed, "declared out")
+	assert.True(t, out.Folded)
+	assert.Equal(t, hand.Rounds, out.Counts[gamelog.KindDropOut])
+
+	// Two players went in, so the round was contested and somebody won it.
+	assert.True(t, hand.Participant(1).WentToShowdown)
+	assert.True(t, hand.Participant(3).WentToShowdown)
+
+	won := 0
+	for _, p := range hand.Participants {
+		if p.Won {
+			won++
+		}
+	}
+	assert.NotZero(t, won, "a contested round has a winner")
+
+	// Every player who was dealt in should have their starting cards recorded.
+	for _, id := range []int64{1, 2, 3} {
+		assert.NotEmpty(t, hand.Participant(id).StartingCards, "player %d", id)
+	}
+}

--- a/pkg/playable/guts/parse_log_test.go
+++ b/pkg/playable/guts/parse_log_test.go
@@ -1,0 +1,134 @@
+package guts
+
+import (
+	"encoding/json"
+	"testing"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalLog serializes the live gameLog exactly as EndGame persists it, so the
+// tests below exercise the real on-disk contract rather than a hand-written
+// approximation of it. A field renamed on gameLog breaks these tests, which is the
+// point: the parser reads what the game actually writes.
+func marshalLog(t *testing.T, log *gameLog) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(log)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestParseGameLog(t *testing.T) {
+	log := &gameLog{
+		Options:    Options{Ante: 25},
+		InitialPot: 50,
+		Players:    []int64{1, 2, 3},
+		Rounds: []*gameLogRound{
+			{
+				Round: 1,
+				Pot:   75,
+				Seats: []*gameLogSeat{
+					{PlayerID: 1, Cards: []*deck.Card{deck.CardFromString("14s"), deck.CardFromString("13s")}},
+					{PlayerID: 2, Cards: []*deck.Card{deck.CardFromString("2c"), deck.CardFromString("7d")}},
+					{PlayerID: 3, Cards: []*deck.Card{deck.CardFromString("9h"), deck.CardFromString("9c")}},
+				},
+				Decisions: []*gameLogDecision{
+					{PlayerID: 1, In: true},
+					{PlayerID: 2, In: false},
+					{PlayerID: 3, In: true},
+				},
+				Result: &gameLogShowdown{
+					Winners:   []int64{3},
+					PlayersIn: []int64{1, 3},
+					PotWon:    75,
+					FinalHands: []*gameLogSeat{
+						{PlayerID: 3, Cards: []*deck.Card{deck.CardFromString("9h"), deck.CardFromString("9c")}},
+					},
+				},
+			},
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	assert.Equal(t, 25, hand.AnteCents)
+	assert.Equal(t, 75, hand.PotCents)
+	assert.Equal(t, 1, hand.Rounds)
+	assert.Len(t, hand.Participants, 3)
+
+	// Player 1 declared in and lost a contested showdown.
+	p1 := hand.Participant(1)
+	assert.True(t, p1.VoluntarilyPlayed)
+	assert.False(t, p1.Folded)
+	assert.True(t, p1.WentToShowdown)
+	assert.False(t, p1.Won)
+	assert.Equal(t, 1, p1.Counts[gamelog.KindStayIn])
+
+	// Player 2 declared out, so they folded the game and never reached a showdown.
+	p2 := hand.Participant(2)
+	assert.False(t, p2.VoluntarilyPlayed)
+	assert.True(t, p2.Folded)
+	assert.False(t, p2.WentToShowdown)
+	assert.Equal(t, 1, p2.Counts[gamelog.KindDropOut])
+
+	// Player 3 declared in and won.
+	p3 := hand.Participant(3)
+	assert.True(t, p3.VoluntarilyPlayed)
+	assert.True(t, p3.WentToShowdown)
+	assert.True(t, p3.Won)
+	assert.Len(t, p3.FinalCards, 2)
+}
+
+// TestParseGameLog_MultiRound covers the rule that folding is a property of the
+// whole game, not of a single round: sitting out one round of a two-round game is
+// not a fold.
+func TestParseGameLog_MultiRound(t *testing.T) {
+	log := &gameLog{
+		Options: Options{Ante: 25},
+		Players: []int64{1, 2},
+		Rounds: []*gameLogRound{
+			{
+				Round:     1,
+				Pot:       50,
+				Decisions: []*gameLogDecision{{PlayerID: 1, In: false}, {PlayerID: 2, In: true}},
+				Result:    &gameLogShowdown{Winners: []int64{2}, PlayersIn: []int64{2}},
+			},
+			{
+				Round:     2,
+				Pot:       100,
+				Decisions: []*gameLogDecision{{PlayerID: 1, In: true}, {PlayerID: 2, In: true}},
+				Result:    &gameLogShowdown{Winners: []int64{1}, PlayersIn: []int64{1, 2}},
+			},
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, hand.Rounds)
+	assert.Equal(t, 100, hand.PotCents, "pot should reflect the final round")
+
+	p1 := hand.Participant(1)
+	assert.True(t, p1.VoluntarilyPlayed, "declared in on round 2")
+	assert.False(t, p1.Folded, "sitting out one round is not folding the game")
+	assert.True(t, p1.Won)
+
+	// Round 1 had a single player in, so player 2 won it without a showdown; round 2
+	// was contested, which is what sets the flag.
+	p2 := hand.Participant(2)
+	assert.True(t, p2.WentToShowdown)
+}
+
+func TestParseGameLog_Invalid(t *testing.T) {
+	hand, err := ParseGameLog(json.RawMessage(`{"rounds":"not-an-array"}`))
+	assert.Nil(t, hand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not decode guts log")
+}

--- a/pkg/playable/passthepoop/parse_log.go
+++ b/pkg/playable/passthepoop/parse_log.go
@@ -1,0 +1,136 @@
+package passthepoop
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+)
+
+// persistedLog mirrors the JSON written by GameLog.
+type persistedLog struct {
+	Edition string           `json:"edition"`
+	Pot     int              `json:"pot"`
+	Ante    int              `json:"ante"`
+	Rounds  []persistedRound `json:"rounds"`
+	Players []int64          `json:"players"`
+	Winner  int64            `json:"winner"`
+}
+
+type persistedRound struct {
+	Round        int               `json:"round"`
+	StartingHand []persistedHand   `json:"startingHand"`
+	GameActions  []persistedAction `json:"gameActions"`
+	LoserGroups  []persistedLosers `json:"loserGroups"`
+}
+
+type persistedHand struct {
+	PlayerID int64      `json:"playerId"`
+	Card     *deck.Card `json:"card"`
+}
+
+type persistedAction struct {
+	GameAction gamelog.RawID `json:"gameAction"`
+	PlayerID   int64         `json:"playerId"`
+}
+
+type persistedLosers struct {
+	RoundLosers []persistedLoser `json:"roundLosers"`
+}
+
+type persistedLoser struct {
+	PlayerID int64 `json:"playerId"`
+}
+
+// ParseGameLog decodes a persisted Pass the Poop log into a normalized hand.
+//
+// Pass the Poop has no betting: players ante once and then decide only whether to
+// keep their card or trade it. There is nothing to wager and nothing to fold, so
+// two of the normalized fields carry a weaker meaning here than they do for the
+// poker variants, and that difference is deliberate rather than an omission:
+//
+//   - VoluntarilyPlayed is true when the player took a discretionary action —
+//     staying, trading, blocking, or going to the deck. It measures engagement
+//     rather than money committed by choice.
+//   - Folded is always false. Losing a life is not a fold; a player cannot choose
+//     to give up a round.
+//
+// A player reaches the showdown in every round they survive to, since every
+// surviving card is compared, and the game's single Winner is the last player
+// standing.
+func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	var log persistedLog
+	if err := json.Unmarshal(raw, &log); err != nil {
+		return nil, fmt.Errorf("could not decode pass the poop log: %w", err)
+	}
+
+	hand := &gamelog.Hand{
+		Variant:   log.Edition,
+		AnteCents: log.Ante,
+		PotCents:  log.Pot,
+		Rounds:    len(log.Rounds),
+	}
+
+	for _, id := range log.Players {
+		hand.Participant(id)
+	}
+
+	acted := make(map[int64]bool)
+
+	for _, round := range log.Rounds {
+		street := "round-" + strconv.Itoa(round.Round)
+
+		if round.Round == 0 {
+			for _, h := range round.StartingHand {
+				hand.Participant(h.PlayerID).StartingCards = []*deck.Card{h.Card}
+			}
+		}
+
+		for _, a := range round.GameActions {
+			kind, voluntary := actionKind(a.GameAction)
+			if voluntary {
+				acted[a.PlayerID] = true
+			}
+
+			hand.AddAction(&gamelog.Action{
+				Street:   street,
+				PlayerID: a.PlayerID,
+				Kind:     kind,
+			})
+		}
+
+		// Everyone dealt into a round contested it: cards are compared, not bet on.
+		for _, h := range round.StartingHand {
+			hand.Participant(h.PlayerID).WentToShowdown = true
+		}
+	}
+
+	for _, p := range hand.Participants {
+		p.VoluntarilyPlayed = acted[p.PlayerID]
+	}
+
+	if log.Winner != 0 {
+		hand.Participant(log.Winner).Won = true
+	}
+
+	return hand, nil
+}
+
+// actionKind maps a Pass the Poop action identifier onto a normalized kind and
+// reports whether it was a discretionary choice. Accepting a trade and drawing
+// from the deck are forced consequences of another player's move, so they do not
+// count as discretionary.
+func actionKind(raw gamelog.RawID) (kind gamelog.Kind, voluntary bool) {
+	switch string(raw) {
+	case "stay":
+		return gamelog.KindStayIn, true
+	case "trade", "block-trade", "flip-king", "go-to-deck":
+		return gamelog.KindTrade, true
+	case "accept-trade", "draw-from-deck":
+		return gamelog.KindTrade, false
+	}
+
+	return gamelog.KindPass, false
+}

--- a/pkg/playable/passthepoop/parse_log.go
+++ b/pkg/playable/passthepoop/parse_log.go
@@ -23,7 +23,6 @@ type persistedRound struct {
 	Round        int               `json:"round"`
 	StartingHand []persistedHand   `json:"startingHand"`
 	GameActions  []persistedAction `json:"gameActions"`
-	LoserGroups  []persistedLosers `json:"loserGroups"`
 }
 
 type persistedHand struct {
@@ -34,14 +33,6 @@ type persistedHand struct {
 type persistedAction struct {
 	GameAction gamelog.RawID `json:"gameAction"`
 	PlayerID   int64         `json:"playerId"`
-}
-
-type persistedLosers struct {
-	RoundLosers []persistedLoser `json:"roundLosers"`
-}
-
-type persistedLoser struct {
-	PlayerID int64 `json:"playerId"`
 }
 
 // ParseGameLog decodes a persisted Pass the Poop log into a normalized hand.
@@ -122,13 +113,23 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 // reports whether it was a discretionary choice. Accepting a trade and drawing
 // from the deck are forced consequences of another player's move, so they do not
 // count as discretionary.
+//
+// The identifier is resolved through GameActionFromID and matched against the
+// typed constants rather than against string literals, so renaming an action in
+// GameAction.ID is a compile error here instead of silently reclassifying every
+// action in every persisted log.
 func actionKind(raw gamelog.RawID) (kind gamelog.Kind, voluntary bool) {
-	switch string(raw) {
-	case "stay":
+	a, err := GameActionFromID(string(raw))
+	if err != nil {
+		return gamelog.KindPass, false
+	}
+
+	switch a {
+	case ActionStay:
 		return gamelog.KindStayIn, true
-	case "trade", "block-trade", "flip-king", "go-to-deck":
+	case ActionTrade, ActionBlockTrade, ActionFlipKing, ActionGoToDeck:
 		return gamelog.KindTrade, true
-	case "accept-trade", "draw-from-deck":
+	case ActionAccept, ActionDrawFromDeck:
 		return gamelog.KindTrade, false
 	}
 

--- a/pkg/playable/passthepoop/parse_log.go
+++ b/pkg/playable/passthepoop/parse_log.go
@@ -73,6 +73,10 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 	for _, round := range log.Rounds {
 		street := "round-" + strconv.Itoa(round.Round)
 
+		// The writer numbers rounds from 0, so round.Round == 0 is what identifies
+		// the first round here (unlike guts, which uses slice index instead of the
+		// persisted round number). If the writer ever changed its numbering, this
+		// check would silently attribute the wrong round's deal as starting cards.
 		if round.Round == 0 {
 			for _, h := range round.StartingHand {
 				hand.Participant(h.PlayerID).StartingCards = []*deck.Card{h.Card}

--- a/pkg/playable/passthepoop/parse_log_test.go
+++ b/pkg/playable/passthepoop/parse_log_test.go
@@ -1,0 +1,88 @@
+package passthepoop
+
+import (
+	"encoding/json"
+	"testing"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalLog serializes the live GameLog exactly as EndGame persists it, so these
+// tests exercise the real on-disk contract rather than a hand-written
+// approximation of it.
+func marshalLog(t *testing.T, log *GameLog) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(log)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestParseGameLog(t *testing.T) {
+	log := &GameLog{
+		Edition: "diarrhea",
+		Pot:     300,
+		Ante:    25,
+		Lives:   3,
+		Players: []int64{1, 2, 3},
+		Winner:  2,
+		Rounds: []*GameLogRound{
+			{
+				Round: 0,
+				StartingHand: []*GameLogHand{
+					{PlayerID: 1, Card: deck.CardFromString("2c")},
+					{PlayerID: 2, Card: deck.CardFromString("13s")},
+					{PlayerID: 3, Card: deck.CardFromString("8h")},
+				},
+				GameActions: []*GameActionDetails{
+					{GameAction: ActionTrade, PlayerID: 1, SecondaryPlayerID: 2},
+					{GameAction: ActionAccept, PlayerID: 2},
+					{GameAction: ActionStay, PlayerID: 3},
+				},
+				LoserGroups: []*LoserGroup{
+					{Order: 0, RoundLosers: []*RoundLoser{{PlayerID: 1}}},
+				},
+			},
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	assert.Equal(t, "diarrhea", hand.Variant)
+	assert.Equal(t, 25, hand.AnteCents)
+	assert.Equal(t, 300, hand.PotCents)
+	assert.Equal(t, 1, hand.Rounds)
+	assert.Len(t, hand.Actions, 3)
+
+	// GameAction is an int enum written as an {"id","name"} object with no matching
+	// UnmarshalJSON, so this pins that the object form decodes by id.
+	assert.Equal(t, gamelog.KindTrade, hand.Actions[0].Kind)
+	assert.Equal(t, gamelog.KindStayIn, hand.Actions[2].Kind)
+
+	// Trading is a choice; accepting a trade forced on you is not.
+	assert.True(t, hand.Participant(1).VoluntarilyPlayed)
+	assert.False(t, hand.Participant(2).VoluntarilyPlayed)
+	assert.True(t, hand.Participant(3).VoluntarilyPlayed)
+
+	// Every player dealt into a round contests it: there is nothing to fold.
+	for _, id := range []int64{1, 2, 3} {
+		assert.True(t, hand.Participant(id).WentToShowdown, "player %d", id)
+		assert.False(t, hand.Participant(id).Folded, "player %d", id)
+	}
+
+	assert.True(t, hand.Participant(2).Won)
+	assert.False(t, hand.Participant(1).Won)
+}
+
+func TestParseGameLog_Invalid(t *testing.T) {
+	hand, err := ParseGameLog(json.RawMessage(`{"rounds":7}`))
+	assert.Nil(t, hand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not decode pass the poop log")
+}

--- a/pkg/playable/poker/littlel/parse_log.go
+++ b/pkg/playable/poker/littlel/parse_log.go
@@ -14,7 +14,6 @@ import (
 // live struct.
 type persistedLog struct {
 	Ante         int             `json:"ante"`
-	InitialDeal  int             `json:"initialDeal"`
 	Seats        []persistedSeat `json:"seats"`
 	Community    []*deck.Card    `json:"community"`
 	Actions      []persistedAct  `json:"actions"`
@@ -27,16 +26,12 @@ type persistedSeat struct {
 	StartingHand []*deck.Card `json:"startingHand"`
 }
 
-// persistedAct carries Round as an integer because littlel's round type is a plain
-// int with no custom marshalling, unlike the named streets the other poker
-// variants record.
+// persistedAct embeds the shared betting action and adds the one field Little L
+// records differently: a plain integer round rather than a named street. Street is
+// left empty by the decode and filled in below.
 type persistedAct struct {
-	Round    int           `json:"round"`
-	PlayerID int64         `json:"playerId"`
-	Action   gamelog.RawID `json:"action"`
-	Amount   int           `json:"amount"`
-	Cards    []*deck.Card  `json:"cards"`
-	AllIn    bool          `json:"allIn"`
+	gamelog.BettingAction
+	Round int `json:"round"`
 }
 
 type persistedPart struct {
@@ -64,14 +59,8 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 
 	actions := make([]gamelog.BettingAction, 0, len(log.Actions))
 	for _, a := range log.Actions {
-		actions = append(actions, gamelog.BettingAction{
-			Street:   "round-" + strconv.Itoa(a.Round),
-			PlayerID: a.PlayerID,
-			Action:   a.Action,
-			Amount:   a.Amount,
-			Cards:    a.Cards,
-			AllIn:    a.AllIn,
-		})
+		a.Street = "round-" + strconv.Itoa(a.Round)
+		actions = append(actions, a.BettingAction)
 	}
 	hand.ApplyBettingActions(actions)
 

--- a/pkg/playable/poker/littlel/parse_log.go
+++ b/pkg/playable/poker/littlel/parse_log.go
@@ -1,0 +1,92 @@
+package littlel
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+)
+
+// persistedLog mirrors the JSON written by gameLog. See the equivalent type in the
+// texasholdem package for why the persisted form is declared separately from the
+// live struct.
+type persistedLog struct {
+	Ante         int             `json:"ante"`
+	InitialDeal  int             `json:"initialDeal"`
+	Seats        []persistedSeat `json:"seats"`
+	Community    []*deck.Card    `json:"community"`
+	Actions      []persistedAct  `json:"actions"`
+	Participants []persistedPart `json:"participants"`
+	Winners      map[int64]int   `json:"winners"`
+}
+
+type persistedSeat struct {
+	PlayerID     int64        `json:"playerId"`
+	StartingHand []*deck.Card `json:"startingHand"`
+}
+
+// persistedAct carries Round as an integer because littlel's round type is a plain
+// int with no custom marshalling, unlike the named streets the other poker
+// variants record.
+type persistedAct struct {
+	Round    int           `json:"round"`
+	PlayerID int64         `json:"playerId"`
+	Action   gamelog.RawID `json:"action"`
+	Amount   int           `json:"amount"`
+	Cards    []*deck.Card  `json:"cards"`
+	AllIn    bool          `json:"allIn"`
+}
+
+type persistedPart struct {
+	PlayerID int64        `json:"playerId"`
+	DidFold  bool         `json:"didFold"`
+	Hand     []*deck.Card `json:"hand"`
+}
+
+// ParseGameLog decodes a persisted Little L log into a normalized hand.
+func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	var log persistedLog
+	if err := json.Unmarshal(raw, &log); err != nil {
+		return nil, fmt.Errorf("could not decode little l log: %w", err)
+	}
+
+	hand := &gamelog.Hand{
+		AnteCents: log.Ante,
+		Rounds:    1,
+		Board:     log.Community,
+	}
+
+	for _, seat := range log.Seats {
+		hand.Participant(seat.PlayerID).StartingCards = seat.StartingHand
+	}
+
+	actions := make([]gamelog.BettingAction, 0, len(log.Actions))
+	for _, a := range log.Actions {
+		actions = append(actions, gamelog.BettingAction{
+			Street:   "round-" + strconv.Itoa(a.Round),
+			PlayerID: a.PlayerID,
+			Action:   a.Action,
+			Amount:   a.Amount,
+			Cards:    a.Cards,
+			AllIn:    a.AllIn,
+		})
+	}
+	hand.ApplyBettingActions(actions)
+
+	folded := make(map[int64]bool, len(log.Participants))
+	for _, p := range log.Participants {
+		folded[p.PlayerID] = p.DidFold
+		hand.Participant(p.PlayerID).FinalCards = p.Hand
+	}
+
+	// The pot is not stored on the log, so reconstruct it from what was paid out.
+	for _, won := range log.Winners {
+		hand.PotCents += won
+	}
+
+	hand.ResolveShowdown(folded, log.Winners)
+
+	return hand, nil
+}

--- a/pkg/playable/poker/littlel/parse_log_test.go
+++ b/pkg/playable/poker/littlel/parse_log_test.go
@@ -1,0 +1,109 @@
+package littlel
+
+import (
+	"encoding/json"
+	"testing"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+	"mondaynightpoker-server/pkg/playable/poker/action"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalLog serializes the live gameLog exactly as EndGame persists it, so these
+// tests exercise the real on-disk contract rather than a hand-written
+// approximation of it.
+func marshalLog(t *testing.T, log *gameLog) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(log)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestParseGameLog(t *testing.T) {
+	log := &gameLog{
+		Ante:        25,
+		InitialDeal: 3,
+		TradeIns:    []int{0, 1, 2},
+		Community:   []*deck.Card{deck.CardFromString("14s"), deck.CardFromString("7d")},
+		Seats: []*gameLogSeat{
+			{PlayerID: 1, TableStake: 1000, StartingHand: []*deck.Card{deck.CardFromString("13s"), deck.CardFromString("13d")}},
+			{PlayerID: 2, TableStake: 1000, StartingHand: []*deck.Card{deck.CardFromString("3c"), deck.CardFromString("8h")}},
+		},
+		Actions: []*gameLogAction{
+			{Round: 1, PlayerID: 1, Action: action.Bet, Amount: 50},
+			{Round: 1, PlayerID: 2, Action: action.Call, Amount: 50},
+			{Round: 2, PlayerID: 1, Action: action.Trade, Cards: []*deck.Card{deck.CardFromString("13d")}},
+			{Round: 3, PlayerID: 1, Action: action.Check},
+			{Round: 3, PlayerID: 2, Action: action.Check},
+		},
+		Participants: []*participantJSON{
+			{PlayerID: 1, Hand: deck.Hand{deck.CardFromString("13s")}},
+			{PlayerID: 2, Hand: deck.Hand{deck.CardFromString("3c")}},
+		},
+		Winners: map[int64]int{1: 150},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	assert.Equal(t, 25, hand.AnteCents)
+	assert.Len(t, hand.Board, 2)
+	assert.Len(t, hand.Actions, 5)
+
+	// Little L records an integer round rather than a named street.
+	assert.Equal(t, "round-1", hand.Actions[0].Street)
+	assert.Equal(t, "round-3", hand.Actions[3].Street)
+
+	// The pot is not stored on the log, so it is reconstructed from the payouts.
+	assert.Equal(t, 150, hand.PotCents)
+
+	p1 := hand.Participant(1)
+	assert.True(t, p1.VoluntarilyPlayed)
+	assert.True(t, p1.WentToShowdown)
+	assert.True(t, p1.Won)
+	assert.Equal(t, 1, p1.Counts[gamelog.KindTrade])
+
+	p2 := hand.Participant(2)
+	assert.True(t, p2.VoluntarilyPlayed)
+	assert.True(t, p2.WentToShowdown)
+	assert.False(t, p2.Won)
+}
+
+func TestParseGameLog_Folded(t *testing.T) {
+	log := &gameLog{
+		Ante:  25,
+		Seats: []*gameLogSeat{{PlayerID: 1}, {PlayerID: 2}},
+		Actions: []*gameLogAction{
+			{Round: 1, PlayerID: 1, Action: action.Bet, Amount: 50},
+			{Round: 1, PlayerID: 2, Action: action.Fold},
+		},
+		Participants: []*participantJSON{
+			{PlayerID: 1},
+			{PlayerID: 2, DidFold: true},
+		},
+		Winners: map[int64]int{1: 100},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	p1 := hand.Participant(1)
+	assert.True(t, p1.Won)
+	assert.False(t, p1.WentToShowdown)
+
+	p2 := hand.Participant(2)
+	assert.True(t, p2.Folded)
+	assert.False(t, p2.VoluntarilyPlayed)
+}
+
+func TestParseGameLog_Invalid(t *testing.T) {
+	hand, err := ParseGameLog(json.RawMessage(`{"actions":true}`))
+	assert.Nil(t, hand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not decode little l log")
+}

--- a/pkg/playable/poker/sevencard/parse_log.go
+++ b/pkg/playable/poker/sevencard/parse_log.go
@@ -50,6 +50,11 @@ type persistedPart struct {
 // Seven Card has no single starting hand: cards arrive one per street, some face
 // up and some face down. The starting cards reported for each player are therefore
 // the cards from the initial deal only, reassembled from the deal records.
+//
+// The action stream carries more than the betting: a variant that implements
+// InteractiveVariant records its own moves into the same list, in the order they
+// were taken, so the parser hands ApplyBettingActionsFunc a mapping for them (see
+// variantActionKind) rather than letting them fall out of the history.
 func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 	var log persistedLog
 	if err := json.Unmarshal(raw, &log); err != nil {
@@ -74,7 +79,7 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 		}
 	}
 
-	hand.ApplyBettingActions(log.Actions)
+	hand.ApplyBettingActionsFunc(log.Actions, variantActionKind)
 
 	folded := make(map[int64]bool, len(log.FinalState.Participants))
 	for _, p := range log.FinalState.Participants {
@@ -84,4 +89,34 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 	hand.ResolveShowdown(folded, log.FinalState.Winners)
 
 	return hand, nil
+}
+
+// variantActionKind maps a Seven Card variant action identifier onto a normalized
+// kind. It is the fallback ParseGameLog gives ApplyBettingActionsFunc, so it only
+// ever sees identifiers that are not part of the shared betting vocabulary.
+//
+// Chiggs is the one variant with actions of its own: a player may flip a face-down
+// mushroom to force their neighbors out, and a neighbor holding an antidote may
+// play it to survive. Both are recorded by Game.Action into the same stream as the
+// betting and interleaved with it, so dropping them would leave a hand history that
+// silently skips the moves that decided the hand.
+//
+// Both normalize to KindPlayCard. Each commits a specific card from the player's
+// hand to change the state of the game, which is what KindPlayCard describes; the
+// alternatives are worse fits, since neither trades or discards a card for another
+// and neither is a wager. Neither puts money in the pot, and
+// ApplyBettingActionsFunc guarantees that an action resolved here never counts
+// toward VoluntarilyPlayed — the amount recorded for both is zero, so the wagered
+// totals are unaffected as well.
+//
+// The switch matches the typed constants rather than string literals, so renaming
+// one in action.go is a compile error here instead of an action that quietly
+// disappears from every hand history written afterward.
+func variantActionKind(raw gamelog.RawID) (gamelog.Kind, bool) {
+	switch Action(raw) {
+	case ActionFlipMushroom, ActionPlayAntidote:
+		return gamelog.KindPlayCard, true
+	}
+
+	return "", false
 }

--- a/pkg/playable/poker/sevencard/parse_log.go
+++ b/pkg/playable/poker/sevencard/parse_log.go
@@ -1,0 +1,108 @@
+package sevencard
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+)
+
+// persistedLog mirrors the JSON written by gameLog. See the equivalent type in the
+// texasholdem package for why the persisted form is declared separately from the
+// live struct.
+type persistedLog struct {
+	Variant    string          `json:"variant"`
+	Ante       int             `json:"ante"`
+	Seats      []persistedSeat `json:"seats"`
+	Deals      []persistedDeal `json:"deals"`
+	Actions    []persistedAct  `json:"actions"`
+	FinalState persistedState  `json:"finalState"`
+}
+
+type persistedSeat struct {
+	PlayerID int64 `json:"playerId"`
+}
+
+type persistedDealCard struct {
+	PlayerID int64      `json:"playerId"`
+	Card     *deck.Card `json:"card"`
+}
+
+type persistedDeal struct {
+	Street string              `json:"street"`
+	Cards  []persistedDealCard `json:"cards"`
+}
+
+type persistedAct struct {
+	Street   string        `json:"street"`
+	PlayerID int64         `json:"playerId"`
+	Action   gamelog.RawID `json:"action"`
+	Amount   int           `json:"amount"`
+	Cards    []*deck.Card  `json:"cards"`
+	AllIn    bool          `json:"allIn"`
+}
+
+type persistedState struct {
+	Participants []persistedPart `json:"participants"`
+	Pot          int             `json:"pot"`
+	Winners      map[int64]int   `json:"winners"`
+}
+
+type persistedPart struct {
+	PlayerID int64        `json:"playerId"`
+	DidFold  bool         `json:"didFold"`
+	Hand     []*deck.Card `json:"hand"`
+}
+
+// ParseGameLog decodes a persisted Seven Card log into a normalized hand.
+//
+// Seven Card has no single starting hand: cards arrive one per street, some face
+// up and some face down. The starting cards reported for each player are therefore
+// the cards from the initial deal only, reassembled from the deal records.
+func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	var log persistedLog
+	if err := json.Unmarshal(raw, &log); err != nil {
+		return nil, fmt.Errorf("could not decode seven card log: %w", err)
+	}
+
+	hand := &gamelog.Hand{
+		Variant:   log.Variant,
+		AnteCents: log.Ante,
+		PotCents:  log.FinalState.Pot,
+		Rounds:    1,
+	}
+
+	for _, seat := range log.Seats {
+		hand.Participant(seat.PlayerID)
+	}
+
+	if len(log.Deals) > 0 {
+		for _, c := range log.Deals[0].Cards {
+			p := hand.Participant(c.PlayerID)
+			p.StartingCards = append(p.StartingCards, c.Card)
+		}
+	}
+
+	actions := make([]gamelog.BettingAction, 0, len(log.Actions))
+	for _, a := range log.Actions {
+		actions = append(actions, gamelog.BettingAction{
+			Street:   a.Street,
+			PlayerID: a.PlayerID,
+			Action:   a.Action,
+			Amount:   a.Amount,
+			Cards:    a.Cards,
+			AllIn:    a.AllIn,
+		})
+	}
+	hand.ApplyBettingActions(actions)
+
+	folded := make(map[int64]bool, len(log.FinalState.Participants))
+	for _, p := range log.FinalState.Participants {
+		folded[p.PlayerID] = p.DidFold
+		hand.Participant(p.PlayerID).FinalCards = p.Hand
+	}
+	hand.ResolveShowdown(folded, log.FinalState.Winners)
+
+	return hand, nil
+}

--- a/pkg/playable/poker/sevencard/parse_log.go
+++ b/pkg/playable/poker/sevencard/parse_log.go
@@ -12,12 +12,12 @@ import (
 // texasholdem package for why the persisted form is declared separately from the
 // live struct.
 type persistedLog struct {
-	Variant    string          `json:"variant"`
-	Ante       int             `json:"ante"`
-	Seats      []persistedSeat `json:"seats"`
-	Deals      []persistedDeal `json:"deals"`
-	Actions    []persistedAct  `json:"actions"`
-	FinalState persistedState  `json:"finalState"`
+	Variant    string                  `json:"variant"`
+	Ante       int                     `json:"ante"`
+	Seats      []persistedSeat         `json:"seats"`
+	Deals      []persistedDeal         `json:"deals"`
+	Actions    []gamelog.BettingAction `json:"actions"`
+	FinalState persistedState          `json:"finalState"`
 }
 
 type persistedSeat struct {
@@ -30,17 +30,7 @@ type persistedDealCard struct {
 }
 
 type persistedDeal struct {
-	Street string              `json:"street"`
-	Cards  []persistedDealCard `json:"cards"`
-}
-
-type persistedAct struct {
-	Street   string        `json:"street"`
-	PlayerID int64         `json:"playerId"`
-	Action   gamelog.RawID `json:"action"`
-	Amount   int           `json:"amount"`
-	Cards    []*deck.Card  `json:"cards"`
-	AllIn    bool          `json:"allIn"`
+	Cards []persistedDealCard `json:"cards"`
 }
 
 type persistedState struct {
@@ -84,18 +74,7 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 		}
 	}
 
-	actions := make([]gamelog.BettingAction, 0, len(log.Actions))
-	for _, a := range log.Actions {
-		actions = append(actions, gamelog.BettingAction{
-			Street:   a.Street,
-			PlayerID: a.PlayerID,
-			Action:   a.Action,
-			Amount:   a.Amount,
-			Cards:    a.Cards,
-			AllIn:    a.AllIn,
-		})
-	}
-	hand.ApplyBettingActions(actions)
+	hand.ApplyBettingActions(log.Actions)
 
 	folded := make(map[int64]bool, len(log.FinalState.Participants))
 	for _, p := range log.FinalState.Participants {

--- a/pkg/playable/poker/sevencard/parse_log_test.go
+++ b/pkg/playable/poker/sevencard/parse_log_test.go
@@ -115,6 +115,119 @@ func TestParseGameLog_Showdown(t *testing.T) {
 	assert.True(t, hand.Participant(2).Won)
 }
 
+// TestParseGameLog_VariantActions covers the Chiggs mushroom/antidote moves, which
+// Game.Action records into the same stream as the betting. They must survive
+// parsing with their position intact, since where they fall relative to the betting
+// is the only thing that says when the mushroom was flipped.
+func TestParseGameLog_VariantActions(t *testing.T) {
+	log := &gameLog{
+		Variant: "chiggs",
+		Ante:    25,
+		Seats:   []*gameLogSeat{{PlayerID: 1}, {PlayerID: 2}},
+		Actions: []*gameLogAction{
+			{Street: "fourth-street", PlayerID: 1, Action: ActionBet, Amount: 50},
+			{Street: "fourth-street", PlayerID: 2, Action: ActionFlipMushroom},
+			{Street: "fourth-street", PlayerID: 1, Action: ActionPlayAntidote},
+			{Street: "fourth-street", PlayerID: 2, Action: ActionCall, Amount: 50},
+		},
+		FinalState: GameState{
+			Pot:     150,
+			Winners: map[int64]int{1: 150},
+			Participants: []*participantJSON{
+				{PlayerID: 1},
+				{PlayerID: 2},
+			},
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	require.Len(t, hand.Actions, 4, "no variant action is dropped")
+
+	// The two variant actions keep the sequence positions they were recorded in,
+	// interleaved with the betting rather than appended after it.
+	assert.Equal(t, gamelog.KindBet, hand.Actions[0].Kind)
+	assert.Equal(t, gamelog.KindPlayCard, hand.Actions[1].Kind)
+	assert.Equal(t, gamelog.KindPlayCard, hand.Actions[2].Kind)
+	assert.Equal(t, gamelog.KindCall, hand.Actions[3].Kind)
+
+	for i, a := range hand.Actions {
+		assert.Equal(t, i, a.Sequence)
+		assert.Equal(t, "fourth-street", a.Street)
+	}
+
+	assert.Equal(t, int64(2), hand.Actions[1].PlayerID, "player 2 flipped the mushroom")
+	assert.Equal(t, int64(1), hand.Actions[2].PlayerID, "player 1 played the antidote")
+
+	// Neither move puts money in the pot, so neither shows up in the wagered totals
+	// and neither can be what makes a player voluntarily played.
+	assert.Zero(t, hand.Actions[1].AmountCents)
+	assert.Zero(t, hand.Actions[2].AmountCents)
+
+	p1 := hand.Participant(1)
+	assert.Equal(t, 50, p1.AmountWageredCents)
+	assert.True(t, p1.VoluntarilyPlayed, "the bet is what qualifies, not the antidote")
+	assert.Equal(t, 1, p1.Counts[gamelog.KindPlayCard])
+	assert.False(t, p1.Folded)
+
+	p2 := hand.Participant(2)
+	assert.Equal(t, 50, p2.AmountWageredCents)
+	assert.True(t, p2.VoluntarilyPlayed, "the call is what qualifies, not the mushroom")
+	assert.Equal(t, 1, p2.Counts[gamelog.KindPlayCard])
+}
+
+// TestParseGameLog_VariantActionOnly proves the variant moves alone never make a
+// player count as having voluntarily played: only money in by choice does that.
+func TestParseGameLog_VariantActionOnly(t *testing.T) {
+	log := &gameLog{
+		Variant: "chiggs",
+		Ante:    25,
+		Seats:   []*gameLogSeat{{PlayerID: 1}, {PlayerID: 2}},
+		Actions: []*gameLogAction{
+			{Street: "third-street", PlayerID: 1, Action: ActionFlipMushroom},
+			{Street: "third-street", PlayerID: 2, Action: ActionPlayAntidote},
+			{Street: "third-street", PlayerID: 1, Action: ActionCheck},
+			{Street: "third-street", PlayerID: 2, Action: ActionCheck},
+		},
+		FinalState: GameState{
+			Pot:     50,
+			Winners: map[int64]int{1: 50},
+			Participants: []*participantJSON{
+				{PlayerID: 1},
+				{PlayerID: 2},
+			},
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	require.Len(t, hand.Actions, 4)
+
+	for _, id := range []int64{1, 2} {
+		p := hand.Participant(id)
+		assert.False(t, p.VoluntarilyPlayed, "player %d only checked", id)
+		assert.Zero(t, p.AmountWageredCents)
+		assert.False(t, p.Folded)
+		assert.True(t, p.WentToShowdown)
+	}
+}
+
+// TestVariantActionKind pins the mapping itself, including the unknown-identifier
+// case that keeps a log from a newer game version readable.
+func TestVariantActionKind(t *testing.T) {
+	for _, a := range []Action{ActionFlipMushroom, ActionPlayAntidote} {
+		kind, ok := variantActionKind(gamelog.RawID(a))
+		assert.True(t, ok, "%s should map", a)
+		assert.Equal(t, gamelog.KindPlayCard, kind)
+	}
+
+	kind, ok := variantActionKind(gamelog.RawID("summon-chigg"))
+	assert.False(t, ok)
+	assert.Equal(t, gamelog.Kind(""), kind)
+}
+
 func TestParseGameLog_Invalid(t *testing.T) {
 	hand, err := ParseGameLog(json.RawMessage(`{"seats":"nope"}`))
 	assert.Nil(t, hand)

--- a/pkg/playable/poker/sevencard/parse_log_test.go
+++ b/pkg/playable/poker/sevencard/parse_log_test.go
@@ -1,0 +1,123 @@
+package sevencard
+
+import (
+	"encoding/json"
+	"testing"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalLog serializes the live gameLog exactly as EndGame persists it, so these
+// tests exercise the real on-disk contract rather than a hand-written
+// approximation of it.
+func marshalLog(t *testing.T, log *gameLog) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(log)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestParseGameLog(t *testing.T) {
+	log := &gameLog{
+		Variant: "baseball",
+		Ante:    25,
+		Seats: []*gameLogSeat{
+			{PlayerID: 1, TableStake: 1000, SeatIndex: 0},
+			{PlayerID: 2, TableStake: 1000, SeatIndex: 1},
+		},
+		Deals: []*gameLogDeal{
+			{
+				Street: "initial",
+				Cards: []*gameLogDealCard{
+					{PlayerID: 1, Card: deck.CardFromString("14s"), FaceUp: false},
+					{PlayerID: 1, Card: deck.CardFromString("13s"), FaceUp: true},
+					{PlayerID: 2, Card: deck.CardFromString("3c"), FaceUp: false},
+				},
+			},
+			{
+				Street: "fourth-street",
+				Cards: []*gameLogDealCard{
+					{PlayerID: 1, Card: deck.CardFromString("12s"), FaceUp: true},
+				},
+			},
+		},
+		Actions: []*gameLogAction{
+			{Street: "third-street", PlayerID: 1, Action: ActionBet, Amount: 50},
+			{Street: "third-street", PlayerID: 2, Action: ActionCall, Amount: 50},
+			{Street: "fourth-street", PlayerID: 1, Action: ActionBet, Amount: 100},
+			{Street: "fourth-street", PlayerID: 2, Action: ActionFold},
+		},
+		FinalState: GameState{
+			Pot:     225,
+			Winners: map[int64]int{1: 225},
+			Participants: []*participantJSON{
+				{PlayerID: 1, Hand: deck.Hand{deck.CardFromString("14s"), deck.CardFromString("13s")}},
+				{PlayerID: 2, DidFold: true},
+			},
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	assert.Equal(t, "baseball", hand.Variant)
+	assert.Equal(t, 25, hand.AnteCents)
+	assert.Equal(t, 225, hand.PotCents)
+	assert.Len(t, hand.Actions, 4)
+
+	// Seven Card deals a card per street; starting cards come from the initial deal
+	// only, so player 1's fourth-street card must not appear there.
+	p1 := hand.Participant(1)
+	assert.Len(t, p1.StartingCards, 2)
+	assert.True(t, p1.VoluntarilyPlayed)
+	assert.True(t, p1.Won)
+	assert.False(t, p1.WentToShowdown, "the opponent folded, so nothing was shown down")
+	assert.Equal(t, 150, p1.AmountWageredCents)
+
+	p2 := hand.Participant(2)
+	assert.Len(t, p2.StartingCards, 1)
+	assert.True(t, p2.VoluntarilyPlayed, "called before folding later")
+	assert.True(t, p2.Folded)
+	assert.Equal(t, gamelog.KindFold, hand.Actions[3].Kind)
+}
+
+func TestParseGameLog_Showdown(t *testing.T) {
+	log := &gameLog{
+		Variant: "stud",
+		Ante:    25,
+		Seats:   []*gameLogSeat{{PlayerID: 1}, {PlayerID: 2}},
+		Actions: []*gameLogAction{
+			{Street: "river", PlayerID: 1, Action: ActionCheck},
+			{Street: "river", PlayerID: 2, Action: ActionCheck},
+		},
+		FinalState: GameState{
+			Pot:     100,
+			Winners: map[int64]int{2: 100},
+			Participants: []*participantJSON{
+				{PlayerID: 1},
+				{PlayerID: 2},
+			},
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	assert.True(t, hand.Participant(1).WentToShowdown)
+	assert.False(t, hand.Participant(1).Won)
+	assert.True(t, hand.Participant(2).WentToShowdown)
+	assert.True(t, hand.Participant(2).Won)
+}
+
+func TestParseGameLog_Invalid(t *testing.T) {
+	hand, err := ParseGameLog(json.RawMessage(`{"seats":"nope"}`))
+	assert.Nil(t, hand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not decode seven card log")
+}

--- a/pkg/playable/poker/texasholdem/parse_log.go
+++ b/pkg/playable/poker/texasholdem/parse_log.go
@@ -1,0 +1,89 @@
+package texasholdem
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+)
+
+// persistedLog mirrors the JSON written by gameLog. It is declared separately
+// rather than reusing gameLog because the persisted form is an external contract:
+// re-decoding into the live struct would silently break the moment a field is
+// renamed for the in-memory game, and because Variant and the action identifiers
+// do not round-trip through their own MarshalJSON.
+type persistedLog struct {
+	Variant      gamelog.RawID   `json:"variant"`
+	Ante         int             `json:"ante"`
+	Seats        []persistedSeat `json:"seats"`
+	Actions      []persistedAct  `json:"actions"`
+	Community    []*deck.Card    `json:"community"`
+	Pot          int             `json:"pot"`
+	Participants []persistedPart `json:"participants"`
+}
+
+type persistedSeat struct {
+	PlayerID  int64        `json:"playerId"`
+	HoleCards []*deck.Card `json:"holeCards"`
+}
+
+type persistedAct struct {
+	Street   string        `json:"street"`
+	PlayerID int64         `json:"playerId"`
+	Action   gamelog.RawID `json:"action"`
+	Amount   int           `json:"amount"`
+	Cards    []*deck.Card  `json:"cards"`
+	AllIn    bool          `json:"allIn"`
+}
+
+type persistedPart struct {
+	PlayerID int64        `json:"playerId"`
+	Cards    []*deck.Card `json:"cards"`
+	Folded   bool         `json:"folded"`
+	Winnings int          `json:"winnings"`
+}
+
+// ParseGameLog decodes a persisted Texas Hold'em log into a normalized hand.
+func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	var log persistedLog
+	if err := json.Unmarshal(raw, &log); err != nil {
+		return nil, fmt.Errorf("could not decode texas hold'em log: %w", err)
+	}
+
+	hand := &gamelog.Hand{
+		Variant:   string(log.Variant),
+		AnteCents: log.Ante,
+		PotCents:  log.Pot,
+		Rounds:    1,
+		Board:     log.Community,
+	}
+
+	for _, seat := range log.Seats {
+		hand.Participant(seat.PlayerID).StartingCards = seat.HoleCards
+	}
+
+	actions := make([]gamelog.BettingAction, 0, len(log.Actions))
+	for _, a := range log.Actions {
+		actions = append(actions, gamelog.BettingAction{
+			Street:   a.Street,
+			PlayerID: a.PlayerID,
+			Action:   a.Action,
+			Amount:   a.Amount,
+			Cards:    a.Cards,
+			AllIn:    a.AllIn,
+		})
+	}
+	hand.ApplyBettingActions(actions)
+
+	folded := make(map[int64]bool, len(log.Participants))
+	winnings := make(map[int64]int, len(log.Participants))
+	for _, p := range log.Participants {
+		folded[p.PlayerID] = p.Folded
+		winnings[p.PlayerID] = p.Winnings
+		hand.Participant(p.PlayerID).FinalCards = p.Cards
+	}
+	hand.ResolveShowdown(folded, winnings)
+
+	return hand, nil
+}

--- a/pkg/playable/poker/texasholdem/parse_log.go
+++ b/pkg/playable/poker/texasholdem/parse_log.go
@@ -14,27 +14,18 @@ import (
 // renamed for the in-memory game, and because Variant and the action identifiers
 // do not round-trip through their own MarshalJSON.
 type persistedLog struct {
-	Variant      gamelog.RawID   `json:"variant"`
-	Ante         int             `json:"ante"`
-	Seats        []persistedSeat `json:"seats"`
-	Actions      []persistedAct  `json:"actions"`
-	Community    []*deck.Card    `json:"community"`
-	Pot          int             `json:"pot"`
-	Participants []persistedPart `json:"participants"`
+	Variant      gamelog.RawID           `json:"variant"`
+	Ante         int                     `json:"ante"`
+	Seats        []persistedSeat         `json:"seats"`
+	Actions      []gamelog.BettingAction `json:"actions"`
+	Community    []*deck.Card            `json:"community"`
+	Pot          int                     `json:"pot"`
+	Participants []persistedPart         `json:"participants"`
 }
 
 type persistedSeat struct {
 	PlayerID  int64        `json:"playerId"`
 	HoleCards []*deck.Card `json:"holeCards"`
-}
-
-type persistedAct struct {
-	Street   string        `json:"street"`
-	PlayerID int64         `json:"playerId"`
-	Action   gamelog.RawID `json:"action"`
-	Amount   int           `json:"amount"`
-	Cards    []*deck.Card  `json:"cards"`
-	AllIn    bool          `json:"allIn"`
 }
 
 type persistedPart struct {
@@ -63,18 +54,7 @@ func ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
 		hand.Participant(seat.PlayerID).StartingCards = seat.HoleCards
 	}
 
-	actions := make([]gamelog.BettingAction, 0, len(log.Actions))
-	for _, a := range log.Actions {
-		actions = append(actions, gamelog.BettingAction{
-			Street:   a.Street,
-			PlayerID: a.PlayerID,
-			Action:   a.Action,
-			Amount:   a.Amount,
-			Cards:    a.Cards,
-			AllIn:    a.AllIn,
-		})
-	}
-	hand.ApplyBettingActions(actions)
+	hand.ApplyBettingActions(log.Actions)
 
 	folded := make(map[int64]bool, len(log.Participants))
 	winnings := make(map[int64]int, len(log.Participants))

--- a/pkg/playable/poker/texasholdem/parse_log_test.go
+++ b/pkg/playable/poker/texasholdem/parse_log_test.go
@@ -1,0 +1,141 @@
+package texasholdem
+
+import (
+	"encoding/json"
+	"testing"
+
+	"mondaynightpoker-server/pkg/deck"
+	"mondaynightpoker-server/pkg/playable/gamelog"
+	"mondaynightpoker-server/pkg/playable/poker/action"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalLog serializes the live gameLog exactly as EndGame persists it, so these
+// tests exercise the real on-disk contract rather than a hand-written
+// approximation of it.
+func marshalLog(t *testing.T, log *gameLog) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(log)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestParseGameLog(t *testing.T) {
+	log := &gameLog{
+		Variant:    Pineapple,
+		Ante:       0,
+		SmallBlind: 25,
+		BigBlind:   50,
+		Pot:        300,
+		Community:  deck.Hand{deck.CardFromString("14s"), deck.CardFromString("7d"), deck.CardFromString("2c")},
+		Seats: []*gameLogSeat{
+			{PlayerID: 1, TableStake: 1000, HoleCards: []*deck.Card{deck.CardFromString("13s"), deck.CardFromString("13d")}},
+			{PlayerID: 2, TableStake: 1000, HoleCards: []*deck.Card{deck.CardFromString("3c"), deck.CardFromString("8h")}},
+			{PlayerID: 3, TableStake: 1000, HoleCards: []*deck.Card{deck.CardFromString("9h"), deck.CardFromString("9c")}},
+		},
+		Actions: []*gameLogAction{
+			{Street: "preflop", PlayerID: 1, Action: action.Raise, Amount: 150},
+			{Street: "preflop", PlayerID: 2, Action: action.Fold},
+			{Street: "preflop", PlayerID: 3, Action: action.Call, Amount: 150},
+			{Street: "flop", PlayerID: 1, Action: action.Bet, Amount: 100},
+			{Street: "flop", PlayerID: 3, Action: action.Call, Amount: 100},
+		},
+		Participants: []*participantJSON{
+			{PlayerID: 1, Winnings: 300},
+			{PlayerID: 2, Folded: true},
+			{PlayerID: 3},
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	// The variant is written by MarshalJSON as an {"id","name"} object and has no
+	// matching UnmarshalJSON, so this asserts the object form decodes.
+	assert.Equal(t, "pineapple", hand.Variant)
+	assert.Equal(t, 300, hand.PotCents)
+	assert.Len(t, hand.Board, 3)
+	assert.Len(t, hand.Actions, 5)
+
+	// Actions are written the same way and must survive the same round trip.
+	assert.Equal(t, gamelog.KindRaise, hand.Actions[0].Kind)
+	assert.Equal(t, 150, hand.Actions[0].AmountCents)
+	assert.Equal(t, gamelog.KindFold, hand.Actions[1].Kind)
+
+	p1 := hand.Participant(1)
+	assert.True(t, p1.VoluntarilyPlayed)
+	assert.True(t, p1.WentToShowdown)
+	assert.True(t, p1.Won)
+	assert.Equal(t, 250, p1.AmountWageredCents)
+	assert.Equal(t, 1, p1.Counts[gamelog.KindRaise])
+	assert.Equal(t, 1, p1.Counts[gamelog.KindBet])
+
+	p2 := hand.Participant(2)
+	assert.False(t, p2.VoluntarilyPlayed, "folding preflop is not voluntary play")
+	assert.True(t, p2.Folded)
+	assert.False(t, p2.WentToShowdown)
+
+	p3 := hand.Participant(3)
+	assert.True(t, p3.VoluntarilyPlayed, "calling is voluntary")
+	assert.True(t, p3.WentToShowdown)
+	assert.False(t, p3.Won)
+}
+
+// TestParseGameLog_UncontestedWin covers the distinction between winning a hand
+// and winning it at showdown: a pot everyone else folded out of is not a showdown.
+func TestParseGameLog_UncontestedWin(t *testing.T) {
+	log := &gameLog{
+		Variant: Standard,
+		Pot:     75,
+		Seats: []*gameLogSeat{
+			{PlayerID: 1, HoleCards: []*deck.Card{deck.CardFromString("14s"), deck.CardFromString("14d")}},
+			{PlayerID: 2, HoleCards: []*deck.Card{deck.CardFromString("3c"), deck.CardFromString("8h")}},
+		},
+		Actions: []*gameLogAction{
+			{Street: "preflop", PlayerID: 1, Action: action.Raise, Amount: 75},
+			{Street: "preflop", PlayerID: 2, Action: action.Fold},
+		},
+		Participants: []*participantJSON{
+			{PlayerID: 1, Winnings: 75},
+			{PlayerID: 2, Folded: true},
+		},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	p1 := hand.Participant(1)
+	assert.True(t, p1.Won)
+	assert.False(t, p1.WentToShowdown, "no opponent stayed in, so there was no showdown")
+}
+
+// TestParseGameLog_CheckIsNotVoluntary pins the VPIP rule: a player who only ever
+// checks has not voluntarily put money in the pot.
+func TestParseGameLog_CheckIsNotVoluntary(t *testing.T) {
+	log := &gameLog{
+		Variant: Standard,
+		Seats:   []*gameLogSeat{{PlayerID: 1}, {PlayerID: 2}},
+		Actions: []*gameLogAction{
+			{Street: "flop", PlayerID: 1, Action: action.Check},
+			{Street: "flop", PlayerID: 2, Action: action.Check},
+		},
+		Participants: []*participantJSON{{PlayerID: 1}, {PlayerID: 2}},
+	}
+
+	hand, err := ParseGameLog(marshalLog(t, log))
+	require.NoError(t, err)
+
+	assert.False(t, hand.Participant(1).VoluntarilyPlayed)
+	assert.Equal(t, 1, hand.Participant(1).Counts[gamelog.KindCheck])
+}
+
+func TestParseGameLog_Invalid(t *testing.T) {
+	hand, err := ParseGameLog(json.RawMessage(`{"seats":5}`))
+	assert.Nil(t, hand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not decode texas hold'em log")
+}

--- a/pkg/room/gamefactory/aceydeucey.go
+++ b/pkg/room/gamefactory/aceydeucey.go
@@ -1,9 +1,11 @@
 package gamefactory
 
 import (
+	"encoding/json"
 	"mondaynightpoker-server/pkg/model"
 	"mondaynightpoker-server/pkg/playable"
 	"mondaynightpoker-server/pkg/playable/aceydeucey"
+	"mondaynightpoker-server/pkg/playable/gamelog"
 
 	"github.com/sirupsen/logrus"
 )
@@ -40,4 +42,9 @@ func getAceyDeuceyOptions(data playable.AdditionalData) aceydeucey.Options {
 	}
 
 	return opts
+}
+
+// ParseGameLog decodes a persisted Acey Deucey log into a normalized hand.
+func (a aceyDeuceyFactory) ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	return aceydeucey.ParseGameLog(raw)
 }

--- a/pkg/room/gamefactory/bourre.go
+++ b/pkg/room/gamefactory/bourre.go
@@ -1,9 +1,11 @@
 package gamefactory
 
 import (
+	"encoding/json"
 	"mondaynightpoker-server/pkg/model"
 	"mondaynightpoker-server/pkg/playable"
 	"mondaynightpoker-server/pkg/playable/bourre"
+	"mondaynightpoker-server/pkg/playable/gamelog"
 
 	"github.com/sirupsen/logrus"
 )
@@ -44,4 +46,9 @@ func getBourreOptions(additionalData playable.AdditionalData) bourre.Options {
 	}
 
 	return opts
+}
+
+// ParseGameLog decodes a persisted Bourré log into a normalized hand.
+func (b bourreFactory) ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	return bourre.ParseGameLog(raw)
 }

--- a/pkg/room/gamefactory/gamefactory.go
+++ b/pkg/room/gamefactory/gamefactory.go
@@ -80,6 +80,48 @@ func ParseGameLog(gameType string, raw json.RawMessage) (*gamelog.Hand, error) {
 	return hand, nil
 }
 
+// nameByGroup maps a canonical display group to the factory identifier that
+// produces it. It is derived from the factories themselves rather than written out
+// by hand, relying on the GameFactory contract that
+// model.GameTypeGroup(DisplayName()) yields the factory's group.
+var nameByGroup = func() map[string]string {
+	byGroup := make(map[string]string, len(factories))
+	for name, factory := range factories {
+		byGroup[model.GameTypeGroup(factory.DisplayName())] = name
+	}
+
+	return byGroup
+}()
+
+// NameForStoredGameType resolves a games.game_type value to a registered factory
+// identifier.
+//
+// The column stores a game's full display name rather than its identifier, and
+// that name varies with the options the game was created with ("4-Card Little L
+// (trade: 0, 2)", "Pineapple"). Resolution therefore goes through
+// model.GameTypeGroup, which collapses every display name a game can produce down
+// to one canonical group.
+func NameForStoredGameType(storedGameType string) (string, error) {
+	name, ok := nameByGroup[model.GameTypeGroup(storedGameType)]
+	if !ok {
+		return "", fmt.Errorf("no factory for stored game type: %s", storedGameType)
+	}
+
+	return name, nil
+}
+
+// ParseStoredGameLog decodes a persisted games.data payload into a normalized hand,
+// resolving the games.game_type display name to its factory first. It is the entry
+// point for anything reading logs back out of the database.
+func ParseStoredGameLog(storedGameType string, raw json.RawMessage) (*gamelog.Hand, error) {
+	name, err := NameForStoredGameType(storedGameType)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseGameLog(name, raw)
+}
+
 // Names returns the registered game-type identifiers, sorted.
 func Names() []string {
 	names := make([]string, 0, len(factories))

--- a/pkg/room/gamefactory/gamefactory.go
+++ b/pkg/room/gamefactory/gamefactory.go
@@ -1,9 +1,11 @@
 package gamefactory
 
 import (
+	"encoding/json"
 	"fmt"
 	"mondaynightpoker-server/pkg/model"
 	"mondaynightpoker-server/pkg/playable"
+	"mondaynightpoker-server/pkg/playable/gamelog"
 	"sort"
 
 	"github.com/sirupsen/logrus"
@@ -28,6 +30,15 @@ type GameFactory interface {
 	// model.GameTypeGroup(DisplayName()) must yield the same group as every
 	// real display name the factory's Details can produce.
 	DisplayName() string
+
+	// ParseGameLog decodes the game's persisted games.data payload into a
+	// normalized hand. It is the read counterpart to the log each game writes
+	// when it ends, and lives on the factory so the mapping from a game-type
+	// identifier to the code that understands its log stays in one place.
+	//
+	// Implementations leave Hand.GameType unset; ParseGameLog fills it in from
+	// the identifier it dispatched on.
+	ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error)
 }
 
 // Get returns a factory by the given name
@@ -38,6 +49,35 @@ func Get(name string) (GameFactory, error) {
 	}
 
 	return factory, nil
+}
+
+// ParseGameLog decodes a persisted games.data payload for the given game type into
+// a normalized hand, dispatching to the factory registered under that identifier.
+//
+// A nil or empty payload yields a nil hand and no error: games are recorded before
+// they finish and only get their log on completion, so an unfinished or terminated
+// game legitimately has nothing to parse. Callers distinguish that from a failure
+// by checking for a nil hand.
+func ParseGameLog(gameType string, raw json.RawMessage) (*gamelog.Hand, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+
+	factory, err := Get(gameType)
+	if err != nil {
+		return nil, err
+	}
+
+	hand, err := factory.ParseGameLog(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	if hand != nil {
+		hand.GameType = gameType
+	}
+
+	return hand, nil
 }
 
 // Names returns the registered game-type identifiers, sorted.

--- a/pkg/room/gamefactory/gamefactory.go
+++ b/pkg/room/gamefactory/gamefactory.go
@@ -21,7 +21,11 @@ var factories = map[string]GameFactory{
 	"guts":          gutsFactory{},
 }
 
-// GameFactory is a factory for creating games that implement the Playable interface
+// GameFactory is the registry entry for a game type. It creates games that
+// implement the Playable interface, and also carries the per-game-type knowledge
+// that has no other home: the canonical display name and how to read back a
+// persisted log. Everything keyed by a game-type identifier lives here so a new
+// game cannot be registered with half of it missing.
 type GameFactory interface {
 	CreateGame(logger logrus.FieldLogger, players []*model.PlayerTable, additionalData playable.AdditionalData) (playable.Playable, error)
 	Details(additionalData playable.AdditionalData) (name string, ante int, err error)

--- a/pkg/room/gamefactory/gamefactory.go
+++ b/pkg/room/gamefactory/gamefactory.go
@@ -88,10 +88,23 @@ func ParseGameLog(gameType string, raw json.RawMessage) (*gamelog.Hand, error) {
 // produces it. It is derived from the factories themselves rather than written out
 // by hand, relying on the GameFactory contract that
 // model.GameTypeGroup(DisplayName()) yields the factory's group.
+//
+// That contract is enforced here: if two factories ever collapsed to the same
+// group, a plain map assignment would silently keep whichever factory the map
+// iteration visited last, and NameForStoredGameType would from then on resolve
+// every one of the other factory's stored logs to the wrong parser. Init panics
+// instead, since a colliding group is a programmer error (two factories whose
+// DisplayName values are indistinguishable after grouping) that should fail every
+// test immediately rather than surface as a subtly wrong parse later.
 var nameByGroup = func() map[string]string {
 	byGroup := make(map[string]string, len(factories))
 	for name, factory := range factories {
-		byGroup[model.GameTypeGroup(factory.DisplayName())] = name
+		group := model.GameTypeGroup(factory.DisplayName())
+		if existing, ok := byGroup[group]; ok {
+			panic(fmt.Sprintf("gamefactory: factories %q and %q both resolve to display-type group %q; NameForStoredGameType could not tell their stored logs apart", existing, name, group))
+		}
+
+		byGroup[group] = name
 	}
 
 	return byGroup

--- a/pkg/room/gamefactory/guts.go
+++ b/pkg/room/gamefactory/guts.go
@@ -1,8 +1,10 @@
 package gamefactory
 
 import (
+	"encoding/json"
 	"mondaynightpoker-server/pkg/model"
 	"mondaynightpoker-server/pkg/playable"
+	"mondaynightpoker-server/pkg/playable/gamelog"
 	"mondaynightpoker-server/pkg/playable/guts"
 
 	"github.com/sirupsen/logrus"
@@ -63,4 +65,9 @@ func getGutsOptions(additionalData playable.AdditionalData) guts.Options {
 	}
 
 	return opts
+}
+
+// ParseGameLog decodes a persisted Guts log into a normalized hand.
+func (g gutsFactory) ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	return guts.ParseGameLog(raw)
 }

--- a/pkg/room/gamefactory/little_l.go
+++ b/pkg/room/gamefactory/little_l.go
@@ -1,8 +1,10 @@
 package gamefactory
 
 import (
+	"encoding/json"
 	"mondaynightpoker-server/pkg/model"
 	"mondaynightpoker-server/pkg/playable"
+	"mondaynightpoker-server/pkg/playable/gamelog"
 	"mondaynightpoker-server/pkg/playable/poker/littlel"
 
 	"github.com/sirupsen/logrus"
@@ -54,4 +56,9 @@ func getOptions(additionalData playable.AdditionalData) littlel.Options {
 	}
 
 	return opts
+}
+
+// ParseGameLog decodes a persisted Little L log into a normalized hand.
+func (l littleLFactory) ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	return littlel.ParseGameLog(raw)
 }

--- a/pkg/room/gamefactory/parse_log_test.go
+++ b/pkg/room/gamefactory/parse_log_test.go
@@ -60,6 +60,11 @@ func TestParseGameLog_UnknownGameType(t *testing.T) {
 // game_type resolution depends on: every factory's display name must map back to
 // that same factory. A new game whose DisplayName does not land in its own group
 // would otherwise have its logs silently parsed by the wrong parser.
+//
+// This only proves each factory resolves to itself; it does not cover two
+// factories colliding into the same group, since that case never reaches a test
+// body at all — nameByGroup's package init panics as soon as it detects the
+// collision, failing the whole package before any test runs.
 func TestNameForStoredGameType_RoundTripsEveryFactory(t *testing.T) {
 	for _, name := range Names() {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/room/gamefactory/parse_log_test.go
+++ b/pkg/room/gamefactory/parse_log_test.go
@@ -1,0 +1,64 @@
+package gamefactory
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseGameLog_EveryGameTypeParses is an exhaustiveness check: every game type
+// registered in the factory map must be able to decode its own persisted log. A
+// new game added without a parser fails here rather than at runtime on the first
+// analytics call.
+//
+// The payload used per game type is the minimum well-formed shape for that game,
+// which is enough to prove the parser is wired up and returns a hand tagged with
+// the right game type. The parsers' real behavior is covered by the round-trip
+// tests in each game package, which marshal the live log struct.
+func TestParseGameLog_EveryGameTypeParses(t *testing.T) {
+	// Acey Deucey persists a bare array; every other game persists an object.
+	payloads := map[string]string{
+		"acey-deucey": `[]`,
+	}
+
+	for _, name := range Names() {
+		t.Run(name, func(t *testing.T) {
+			payload, ok := payloads[name]
+			if !ok {
+				payload = `{}`
+			}
+
+			hand, err := ParseGameLog(name, json.RawMessage(payload))
+			require.NoError(t, err)
+			require.NotNil(t, hand)
+			assert.Equal(t, name, hand.GameType, "the dispatcher tags the hand")
+		})
+	}
+}
+
+// TestParseGameLog_NoLog covers games recorded but never finished. A game row is
+// created when the game starts and only gets its data payload when it ends, so a
+// terminated or in-progress game legitimately has nothing to parse.
+func TestParseGameLog_NoLog(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, {}, json.RawMessage(`null`)} {
+		hand, err := ParseGameLog("bourre", raw)
+		assert.NoError(t, err)
+		assert.Nil(t, hand)
+	}
+}
+
+func TestParseGameLog_UnknownGameType(t *testing.T) {
+	hand, err := ParseGameLog("go-fish", json.RawMessage(`{}`))
+	assert.Nil(t, hand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no factory with name: go-fish")
+}
+
+func TestParseGameLog_MalformedPayload(t *testing.T) {
+	hand, err := ParseGameLog("guts", json.RawMessage(`{"rounds":"nope"}`))
+	assert.Nil(t, hand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not decode guts log")
+}

--- a/pkg/room/gamefactory/parse_log_test.go
+++ b/pkg/room/gamefactory/parse_log_test.go
@@ -56,6 +56,64 @@ func TestParseGameLog_UnknownGameType(t *testing.T) {
 	assert.Contains(t, err.Error(), "no factory with name: go-fish")
 }
 
+// TestNameForStoredGameType_RoundTripsEveryFactory pins the contract the stored
+// game_type resolution depends on: every factory's display name must map back to
+// that same factory. A new game whose DisplayName does not land in its own group
+// would otherwise have its logs silently parsed by the wrong parser.
+func TestNameForStoredGameType_RoundTripsEveryFactory(t *testing.T) {
+	for _, name := range Names() {
+		t.Run(name, func(t *testing.T) {
+			factory, err := Get(name)
+			require.NoError(t, err)
+
+			got, err := NameForStoredGameType(factory.DisplayName())
+			require.NoError(t, err)
+			assert.Equal(t, name, got)
+		})
+	}
+}
+
+// TestNameForStoredGameType_RealDisplayNames covers the game_type values actually
+// written to the column, which carry the options the game was created with rather
+// than the bare display name.
+func TestNameForStoredGameType_RealDisplayNames(t *testing.T) {
+	for stored, want := range map[string]string{
+		"Bourré":                        "bourre",
+		"Bourré (ante: 50)":             "bourre",
+		"4-Card Little L (trade: 0, 2)": "little-l",
+		"Texas Hold'em":                 "texas-hold-em",
+		"Pineapple":                     "texas-hold-em",
+		"Lazy Pineapple":                "texas-hold-em",
+		"Acey Deucey":                   "acey-deucey",
+		"Pass the Poop: Diarrhea":       "pass-the-poop",
+		"Guts (2 card)":                 "guts",
+		"Seven-Card Stud":               "seven-card",
+		"Baseball":                      "seven-card",
+		"Follow the Queen":              "seven-card",
+		"Coupons and Clippings":         "seven-card",
+	} {
+		got, err := NameForStoredGameType(stored)
+		require.NoError(t, err, "stored game type %q", stored)
+		assert.Equal(t, want, got, "stored game type %q", stored)
+	}
+}
+
+func TestNameForStoredGameType_Unknown(t *testing.T) {
+	name, err := NameForStoredGameType("Go Fish")
+	assert.Empty(t, name)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no factory for stored game type: Go Fish")
+}
+
+func TestParseStoredGameLog(t *testing.T) {
+	hand, err := ParseStoredGameLog("Bourré (ante: 50)", json.RawMessage(`{"ante":50}`))
+	require.NoError(t, err)
+	require.NotNil(t, hand)
+
+	assert.Equal(t, "bourre", hand.GameType)
+	assert.Equal(t, 50, hand.AnteCents)
+}
+
 func TestParseGameLog_MalformedPayload(t *testing.T) {
 	hand, err := ParseGameLog("guts", json.RawMessage(`{"rounds":"nope"}`))
 	assert.Nil(t, hand)

--- a/pkg/room/gamefactory/pass_the_poop.go
+++ b/pkg/room/gamefactory/pass_the_poop.go
@@ -1,10 +1,12 @@
 package gamefactory
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"mondaynightpoker-server/pkg/model"
 	"mondaynightpoker-server/pkg/playable"
+	"mondaynightpoker-server/pkg/playable/gamelog"
 	"mondaynightpoker-server/pkg/playable/passthepoop"
 
 	"github.com/sirupsen/logrus"
@@ -75,4 +77,9 @@ func (p passThePoopFactory) getOptions(additionalData playable.AdditionalData) (
 	opts.AllowBlocks = allowBlocks
 
 	return opts, nil
+}
+
+// ParseGameLog decodes a persisted Pass the Poop log into a normalized hand.
+func (p passThePoopFactory) ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	return passthepoop.ParseGameLog(raw)
 }

--- a/pkg/room/gamefactory/seven_card.go
+++ b/pkg/room/gamefactory/seven_card.go
@@ -1,9 +1,11 @@
 package gamefactory
 
 import (
+	"encoding/json"
 	"fmt"
 	"mondaynightpoker-server/pkg/model"
 	"mondaynightpoker-server/pkg/playable"
+	"mondaynightpoker-server/pkg/playable/gamelog"
 	"mondaynightpoker-server/pkg/playable/poker/sevencard"
 
 	"github.com/sirupsen/logrus"
@@ -72,4 +74,9 @@ func (s sevenCardFactory) getOptions(additionalData playable.AdditionalData) (se
 	}
 
 	return opts, nil
+}
+
+// ParseGameLog decodes a persisted Seven Card log into a normalized hand.
+func (s sevenCardFactory) ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	return sevencard.ParseGameLog(raw)
 }

--- a/pkg/room/gamefactory/texasholdem.go
+++ b/pkg/room/gamefactory/texasholdem.go
@@ -1,8 +1,10 @@
 package gamefactory
 
 import (
+	"encoding/json"
 	"mondaynightpoker-server/pkg/model"
 	"mondaynightpoker-server/pkg/playable"
+	"mondaynightpoker-server/pkg/playable/gamelog"
 	"mondaynightpoker-server/pkg/playable/poker/texasholdem"
 
 	"github.com/sirupsen/logrus"
@@ -50,4 +52,9 @@ func texasHoldEmOptions(additionData playable.AdditionalData) texasholdem.Option
 	}
 
 	return opts
+}
+
+// ParseGameLog decodes a persisted Texas Hold'em log into a normalized hand.
+func (t texasHoldEmFactory) ParseGameLog(raw json.RawMessage) (*gamelog.Hand, error) {
+	return texasholdem.ParseGameLog(raw)
 }

--- a/sql/0011_tables_deleted.down.sql
+++ b/sql/0011_tables_deleted.down.sql
@@ -1,5 +1,11 @@
 BEGIN;
 
-ALTER TABLE tables DROP COLUMN deleted;
+-- The up migration adds both of these columns; dropping only `deleted` left
+-- `modified` behind, so re-applying the migration failed on the column already
+-- existing and left the schema_migrations row dirty. Dropping `deleted` also
+-- drops tables_deleted_idx, so the index needs no separate statement.
+ALTER TABLE tables
+    DROP COLUMN deleted,
+    DROP COLUMN modified;
 
 COMMIT;

--- a/sql/0014_analytics_join_indexes.down.sql
+++ b/sql/0014_analytics_join_indexes.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX players_tables_transactions_game_id_idx;
+
+DROP INDEX games_table_uuid_idx;
+
+COMMIT;

--- a/sql/0014_analytics_join_indexes.up.sql
+++ b/sql/0014_analytics_join_indexes.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Postgres does not index foreign keys automatically, so both of these join
+-- columns were unindexed. Every read that resolves a game to its ledger rows
+-- (get_game, list_table_games) scanned the whole transactions table, and every
+-- read scoped to one table scanned every game site-wide.
+
+CREATE INDEX players_tables_transactions_game_id_idx ON players_tables_transactions(game_id);
+
+CREATE INDEX games_table_uuid_idx ON games(table_uuid);
+
+COMMIT;


### PR DESCRIPTION
Each game persists a structured log to games.data when it ends, but every
game type writes its own shape: Bourré records tricks and a trump card,
Guts records per-round in/out decisions, and the poker variants record
streets and betting actions. Those logs were only reachable as an opaque
blob, one game at a time, so nothing could be asked of them in aggregate.

Introduce pkg/playable/gamelog, a game-agnostic Hand that keeps who played,
what they chose to do, and how the hand resolved, and give each game package
a ParseGameLog that projects its own persisted JSON onto it. The projection
is lossy on purpose: it drops the game-specific mechanics that cannot be
compared across game types and keeps what can.

Dispatch lives on GameFactory, which is already the single source of truth
mapping a game-type identifier to the code that understands it, so a new
game cannot be registered without a parser. An exhaustiveness test enforces
that.

Two encoding traps are handled rather than worked around. Several enums
(poker actions, hold'em variants, pass-the-poop actions) define MarshalJSON
emitting {"id","name"} but no UnmarshalJSON, so they never round-tripped;
RawID accepts that object form and the bare string form. Bourré's Result and
the Guts/Bourré Options have no JSON tags, so they serialize with Go field
names, which the persisted-shape structs mirror.

Each parser is tested by marshalling the live log struct exactly as EndGame
persists it, so a field renamed on the writer breaks the reader's test.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013iVGbzcY5B6b3ak2wPSGHT